### PR TITLE
add session_id to payload to enable polling kernels

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   check_release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        group: [check_release, link_check]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -19,11 +16,7 @@ jobs:
         run: |
           pip install -e .
       - name: Check Release
-        if: ${{ matrix.group == 'check_release' }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           version_spec: 100.100.100
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run Link Check
-        if: ${{ matrix.group == 'link_check' }}
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-links@v1

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -22,6 +22,7 @@ jobs:
         if: ${{ matrix.group == 'check_release' }}
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
         with:
+          version_spec: 100.100.100
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Link Check
         if: ${{ matrix.group == 'link_check' }}

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,9 +1,8 @@
 name: Check Release
 on:
   push:
-    branches: ["main"]
+    branches: ["1.x"]
   pull_request:
-    branches: ["*"]
 
 jobs:
   check_release:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,3 +28,14 @@ jobs:
       - name: Run the tests
         run: |
           pytest -vv --integration_tests=true tests
+
+  integration_check: # This job does nothing and is only used for the branch protection
+    if: always()
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,9 +1,9 @@
 name: Jupyter Server Integration Tests [Linux]
 on:
   push:
-    branches: ["main"]
+    branches: ["1.x"]
   pull_request:
-    branches: ["*"]
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -1,0 +1,43 @@
+name: "Step 1: Prep Release"
+on:
+  workflow_dispatch:
+    inputs:
+      version_spec:
+        description: "New Version Specifier"
+        default: "next"
+        required: false
+      branch:
+        description: "The branch to target"
+        required: false
+        default: "1.x"
+      post_version_spec:
+        description: "Post Version Specifier"
+        required: false
+      since:
+        description: "Use PRs with activity since this date or git reference"
+        required: false
+      since_last_stable:
+        description: "Use PRs with activity since the last stable git tag"
+        required: false
+        type: boolean
+jobs:
+  prep_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Prep Release
+        id: prep-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
+        with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          version_spec: ${{ github.event.inputs.version_spec }}
+          post_version_spec: ${{ github.event.inputs.post_version_spec }}
+          target: ${{ github.event.inputs.target }}
+          branch: ${{ github.event.inputs.branch }}
+          since: ${{ github.event.inputs.since }}
+          since_last_stable: ${{ github.event.inputs.since_last_stable }}
+
+      - name: "** Next Step **"
+        run: |
+          echo "Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,55 @@
+name: "Step 2: Publish Release"
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "The target branch"
+        required: false
+        default: "1.x"
+      release_url:
+        description: "The URL of the draft GitHub release"
+        required: false
+      steps_to_skip:
+        description: "Comma separated list of steps to skip"
+        required: false
+
+jobs:
+  publish_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Populate Release
+        id: populate-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
+        with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          target: ${{ github.event.inputs.target }}
+          branch: ${{ github.event.inputs.branch }}
+          release_url: ${{ github.event.inputs.release_url }}
+          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
+
+      - name: Finalize Release
+        id: finalize-release
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          PYPI_TOKEN_MAP: ${{ secrets.PYPI_TOKEN_MAP }}
+          TWINE_USERNAME: __token__
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: jupyter-server/jupyter-releaser/.github/actions/finalize-release@v2
+        with:
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          target: ${{ github.event.inputs.target }}
+          release_url: ${{ steps.populate-release.outputs.release_url }}
+
+      - name: "** Next Step **"
+        if: ${{ success() }}
+        run: |
+          echo "Verify the final release"
+          echo ${{ steps.finalize-release.outputs.release_url }}
+
+      - name: "** Failure Message **"
+        if: ${{ failure() }}
+        run: |
+          echo "Failed to Publish the Draft Release Url:"
+          echo ${{ steps.populate-release.outputs.release_url }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,7 +1,7 @@
 name: Jupyter Server Tests
 on:
   push:
-    branches: ["main"]
+    branches: ["1.x"]
   pull_request:
   schedule:
     - cron: "0 8 * * *"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -118,6 +118,7 @@ jobs:
           pip check
       - name: Run the tests
         run: |
+          pip install jupyter_client@https://github.com/blink1073/jupyter_client/archive/refs/heads/synchronous_managers.zip
           pytest -vv || pytest -vv --lf
 
   make_sdist:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -111,7 +111,7 @@ jobs:
           pytest -vv -W default || pytest -vv -W default --lf
 
   check_links:
-    name: Make SDist
+    name: Check Links
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -137,3 +137,18 @@ jobs:
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/test-sdist@v1
+
+  python_tests_check: # This job does nothing and is only used for the branch protection
+    if: always()
+    needs:
+      - build
+      - pre-commit
+      - test_prereleases
+      - make_sdist
+      - test_sdist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -137,6 +137,8 @@ jobs:
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/test-sdist@v1
+        with:
+          test_command: pytest --vv || pytest -vv --lf
 
   python_tests_check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -118,8 +118,7 @@ jobs:
           pip check
       - name: Run the tests
         run: |
-          pip install jupyter_client@https://github.com/blink1073/jupyter_client/archive/refs/heads/synchronous_managers.zip
-          pytest -vv || pytest -vv --lf
+          pytest -vv -W default || pytest -vv -W default --lf
 
   make_sdist:
     name: Make SDist

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,14 +14,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.7", "3.11"]
         include:
           - os: windows-latest
             python-version: "3.9"
           - os: ubuntu-latest
-            python-version: "pypy-3.7"
+            python-version: "pypy-3.8"
           - os: macos-latest
             python-version: "3.8"
+          - os: ubuntu-latest
+            python-version: "3.11"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -48,20 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
-        with:
-          extra_args: --all-files --hook-stage=manual
-      - name: Help message if pre-commit fail
-        if: ${{ failure() }}
-        run: |
-          echo "You can install pre-commit hooks to automatically run formatting"
-          echo "on each commit with:"
-          echo "    pre-commit install"
-          echo "or you can run by hand on staged files with"
-          echo "    pre-commit run"
-          echo "or after-the-fact on already committed files with"
-          echo "    pre-commit run --all-files --hook-stage=manual"
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/pre-commit@v1
 
   test_docs_and_examples:
     name: Test Docs and Examples
@@ -120,6 +110,15 @@ jobs:
         run: |
           pytest -vv -W default || pytest -vv -W default --lf
 
+  check_links:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+
   make_sdist:
     name: Make SDist
     runs-on: ubuntu-latest
@@ -146,7 +145,8 @@ jobs:
       - build
       - pre-commit
       - test_prereleases
-      - make_sdist
+      - test_docs_and_examples
+      - test_minimum_versions
       - test_sdist
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,37 @@
+
+name: Publish package to PyPI
+
+on:
+    release:
+        types:
+        - created
+
+jobs:
+    pypi-publish:
+        name: Upload release to PyPI
+        runs-on: ubuntu-latest
+        environment:
+            name: pypi
+            url: https://pypi.org/p/ocean-jupyter-server
+        permissions:
+            id-token: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            
+            - name: Setup Python 3.9
+              uses: actions/setup-python@v2
+              with:
+                  python-version: 3.9
+
+            - name: Install poetry
+              uses: abatilo/actions-poetry@v2.0.0
+              with:
+                  poetry-version: "1.5.1"
+
+            - name: poetry build
+              run: poetry build
+              shell: bash
+              
+            - name: Publish package distributions to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
         stages: [manual]
 
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.14.2
+    rev: 0.14.3
     hooks:
       - id: check-jsonschema
         name: "Check GitHub Workflows"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         args: ["--line-length", "100"]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         files: \.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,13 @@ repos:
         files: \.py$
         args: [--profile=black]
 
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.942
+    hooks:
+      - id: mypy
+        exclude: examples/simple/setup.py
+        additional_dependencies: [types-requests]
+
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.6.2
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.24.0
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.6...513df7160209764aa9df0f96b7ce5d9f1a596299))
+
+### Enhancements made
+
+- Added error propagation to gateway_request function [#1233](https://github.com/jupyter-server/jupyter_server/pull/1233) ([@broden-wanner](https://github.com/broden-wanner))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2023-02-15&to=2023-04-13&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2023-02-15..2023-04-13&type=Issues) | [@Carreau](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3ACarreau+updated%3A2023-02-15..2023-04-13&type=Issues) | [@codecov](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov+updated%3A2023-02-15..2023-04-13&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2023-02-15..2023-04-13&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adavidbrochart+updated%3A2023-02-15..2023-04-13&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aecharles+updated%3A2023-02-15..2023-04-13&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2023-02-15..2023-04-13&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2023-02-15..2023-04-13&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aminrk+updated%3A2023-02-15..2023-04-13&type=Issues) | [@rajmusuku](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Arajmusuku+updated%3A2023-02-15..2023-04-13&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2023-02-15..2023-04-13&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ayuvipanda+updated%3A2023-02-15..2023-04-13&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AZsailer+updated%3A2023-02-15..2023-04-13&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.23.6
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.5...75bbefa82fa760b63e8ad8a9245f4a8d49503656))
@@ -22,8 +38,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2023-01-12&to=2023-02-15&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2023-01-12..2023-02-15&type=Issues) | [@cmd-ntrf](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acmd-ntrf+updated%3A2023-01-12..2023-02-15&type=Issues) | [@codecov](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov+updated%3A2023-01-12..2023-02-15&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2023-01-12..2023-02-15&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksdev+updated%3A2023-01-12..2023-02-15&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2023-01-12..2023-02-15&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2023-01-12..2023-02-15&type=Issues) | [@xinliupitt](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Axinliupitt+updated%3A2023-01-12..2023-02-15&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.23.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.19.1
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.19.0...690d2f4131b2d65476d05b302a4b3e9a2f052650))
+
+### Bugs fixed
+
+- Wrap the concurrent futures in an asyncio future [#1000](https://github.com/jupyter-server/jupyter_server/pull/1000) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-09-26&to=2022-09-27&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-09-26..2022-09-27&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-09-26..2022-09-27&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.19.0
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.18.1...27bc44c23fba38a4d02b3d9d9eeef45e53eb76ba))
@@ -36,8 +52,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-07-05&to=2022-09-26&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-07-05..2022-09-26&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-07-05..2022-09-26&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adavidbrochart+updated%3A2022-07-05..2022-09-26&type=Issues) | [@divyansshhh](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adivyansshhh+updated%3A2022-07-05..2022-09-26&type=Issues) | [@dlqqq](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adlqqq+updated%3A2022-07-05..2022-09-26&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aecharles+updated%3A2022-07-05..2022-09-26&type=Issues) | [@epignot](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aepignot+updated%3A2022-07-05..2022-09-26&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2022-07-05..2022-09-26&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksdev+updated%3A2022-07-05..2022-09-26&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-07-05..2022-09-26&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aminrk+updated%3A2022-07-05..2022-09-26&type=Issues) | [@thetorpedodog](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Athetorpedodog+updated%3A2022-07-05..2022-09-26&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Avidartf+updated%3A2022-07-05..2022-09-26&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2022-07-05..2022-09-26&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AZsailer+updated%3A2022-07-05..2022-09-26&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.18.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.23.5
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.4...2ca800829c96dc60893dc83715282b7b8fd03d59))
+
+### Bugs fixed
+
+- Backport PR #1162: Reapply preferred_dir fix, now with better backwards compatability [#1167](https://github.com/jupyter-server/jupyter_server/pull/1167) ([@vidartf](https://github.com/vidartf))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-12-20&to=2023-01-12&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-12-20..2023-01-12&type=Issues) | [@Carreau](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3ACarreau+updated%3A2022-12-20..2023-01-12&type=Issues) | [@codecov](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov+updated%3A2022-12-20..2023-01-12&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksdev+updated%3A2022-12-20..2023-01-12&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Avidartf+updated%3A2022-12-20..2023-01-12&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2022-12-20..2023-01-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.23.4
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.3...0a02e42b960875ad578101670128dd0d7df83c47))
@@ -19,8 +35,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-11-21&to=2022-12-20&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-11-21..2022-12-20&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Abollwyvl+updated%3A2022-11-21..2022-12-20&type=Issues) | [@codecov](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov+updated%3A2022-11-21..2022-12-20&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Afcollonval+updated%3A2022-11-21..2022-12-20&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2022-11-21..2022-12-20&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-11-21..2022-12-20&type=Issues) | [@ofek](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aofek+updated%3A2022-11-21..2022-12-20&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Avidartf+updated%3A2022-11-21..2022-12-20&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2022-11-21..2022-12-20&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AZsailer+updated%3A2022-11-21..2022-12-20&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.23.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.21.0
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.19.1...2f529bf5d1f8c68a6b7193f474c9ba025111d743))
+
+### Maintenance and upkeep improvements
+
+- Handle client 8 pending kernels [#1014](https://github.com/jupyter-server/jupyter_server/pull/1014) ([@blink1073](https://github.com/blink1073))
+
+### Documentation improvements
+
+- Pin docutils to fix docs build [#1004](https://github.com/jupyter-server/jupyter_server/pull/1004) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-09-27&to=2022-10-11&type=c))
+
+[@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-09-27..2022-10-11&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-09-27..2022-10-11&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2022-09-27..2022-10-11&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.19.1
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.19.0...690d2f4131b2d65476d05b302a4b3e9a2f052650))
@@ -17,8 +37,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-09-26&to=2022-09-27&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-09-26..2022-09-27&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-09-26..2022-09-27&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.18.1
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.18.0...65d779a12b6e4123de0767de6547e6cdf2d5e7e9))
+
+### Bugs fixed
+
+- Notify ChannelQueue that the response router thread is finishing [#896](https://github.com/jupyter-server/jupyter_server/pull/896) ([@CiprianAnton](https://github.com/CiprianAnton))
+- Make ChannelQueue.get_msg true async [#892](https://github.com/jupyter-server/jupyter_server/pull/892) ([@CiprianAnton](https://github.com/CiprianAnton))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-06-23&to=2022-07-05&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-06-23..2022-07-05&type=Issues) | [@Carreau](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3ACarreau+updated%3A2022-06-23..2022-07-05&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-06-23..2022-07-05&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adavidbrochart+updated%3A2022-06-23..2022-07-05&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aecharles+updated%3A2022-06-23..2022-07-05&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2022-06-23..2022-07-05&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-06-23..2022-07-05&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.18.0
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.17.1...a625db91efc4927c4b6fed4bf67ab995e479c36d))
@@ -32,8 +49,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-06-07&to=2022-06-23&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-06-07..2022-06-23&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-06-07..2022-06-23&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adavidbrochart+updated%3A2022-06-07..2022-06-23&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2022-06-07..2022-06-23&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-06-07..2022-06-23&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.17.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.23.3
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.2...4b19bf0f87a9fe8766ea896ac22f8bcdc3f08064))
+
+### Bugs fixed
+
+- Fix rename_file and delete_file to handle hidden files properly [#1073](https://github.com/jupyter-server/jupyter_server/pull/1073) ([@yacchin1205](https://github.com/yacchin1205))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-11-14&to=2022-11-21&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-11-14..2022-11-21&type=Issues) | [@codecov](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov+updated%3A2022-11-14..2022-11-21&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-11-14..2022-11-21&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-11-14..2022-11-21&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2022-11-14..2022-11-21&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AZsailer+updated%3A2022-11-14..2022-11-21&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.23.2
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.1...1eed592ce93d8863a243f38e327d4a433cfd4b76))
@@ -17,8 +33,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-11-09&to=2022-11-14&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-11-09..2022-11-14&type=Issues) | [@codecov](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov+updated%3A2022-11-09..2022-11-14&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-11-09..2022-11-14&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.23.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.23.2
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.1...1eed592ce93d8863a243f38e327d4a433cfd4b76))
+
+### Maintenance and upkeep improvements
+
+- Fix config merge test for Jupyter Core 5.0 [#1068](https://github.com/jupyter-server/jupyter_server/pull/1068) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-11-09&to=2022-11-14&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-11-09..2022-11-14&type=Issues) | [@codecov](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov+updated%3A2022-11-09..2022-11-14&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-11-09..2022-11-14&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.23.1
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.0...0d8a17939615eafe7a38fb417b7559f4ec6ccf03))
@@ -17,8 +33,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-11-07&to=2022-11-09&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-11-07..2022-11-09&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-11-07..2022-11-09&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.23.1
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.0...0d8a17939615eafe7a38fb417b7559f4ec6ccf03))
+
+### Maintenance and upkeep improvements
+
+- Handle jupyter core warning [#1062](https://github.com/jupyter-server/jupyter_server/pull/1062) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-11-07&to=2022-11-09&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-11-07..2022-11-09&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-11-07..2022-11-09&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.23.0
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.21.0...16953940a16762329ef8f26c8c6d13a91defe0d3))
@@ -21,8 +37,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-10-11&to=2022-11-07&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-10-11..2022-11-07&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-10-11..2022-11-07&type=Issues) | [@divyansshhh](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adivyansshhh+updated%3A2022-10-11..2022-11-07&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.23.4
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.3...0a02e42b960875ad578101670128dd0d7df83c47))
+
+### Bugs fixed
+
+- Raise errors on individual problematic extensions when listing extension [#1139](https://github.com/jupyter-server/jupyter_server/pull/1139) ([@Zsailer](https://github.com/Zsailer))
+- Include base_url at start of kernelspec resources path [#1124](https://github.com/jupyter-server/jupyter_server/pull/1124) ([@bloomsa](https://github.com/bloomsa))
+- Defer webbrowser import [#1095](https://github.com/jupyter-server/jupyter_server/pull/1095) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-11-21&to=2022-12-20&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-11-21..2022-12-20&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Abollwyvl+updated%3A2022-11-21..2022-12-20&type=Issues) | [@codecov](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov+updated%3A2022-11-21..2022-12-20&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Afcollonval+updated%3A2022-11-21..2022-12-20&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2022-11-21..2022-12-20&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-11-21..2022-12-20&type=Issues) | [@ofek](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aofek+updated%3A2022-11-21..2022-12-20&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Avidartf+updated%3A2022-11-21..2022-12-20&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2022-11-21..2022-12-20&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AZsailer+updated%3A2022-11-21..2022-12-20&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.23.3
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.2...4b19bf0f87a9fe8766ea896ac22f8bcdc3f08064))
@@ -17,8 +35,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-11-14&to=2022-11-21&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-11-14..2022-11-21&type=Issues) | [@codecov](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov+updated%3A2022-11-14..2022-11-21&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-11-14..2022-11-21&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-11-14..2022-11-21&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2022-11-14..2022-11-21&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AZsailer+updated%3A2022-11-14..2022-11-21&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.23.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.19.0
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.18.1...27bc44c23fba38a4d02b3d9d9eeef45e53eb76ba))
+
+### New features added
+
+- Backport Inject session identifier into environment variable [#920](https://github.com/jupyter-server/jupyter_server/pull/920) ([@vidartf](https://github.com/vidartf))
+
+### Enhancements made
+
+- Backport #981: Make it easier to pass custom env variables to kernel [#994](https://github.com/jupyter-server/jupyter_server/pull/994) ([@divyansshhh](https://github.com/divyansshhh))
+- Retry certain errors between server and gateway [#944](https://github.com/jupyter-server/jupyter_server/pull/944) ([@kevin-bates](https://github.com/kevin-bates))
+
+### Bugs fixed
+
+- Backport PR #965: Correct content-type headers [#966](https://github.com/jupyter-server/jupyter_server/pull/966) ([@epignot](https://github.com/epignot))
+- avoid creating asyncio.Lock at import time [#935](https://github.com/jupyter-server/jupyter_server/pull/935) ([@minrk](https://github.com/minrk))
+- Fix c.GatewayClient.url snippet syntax [#917](https://github.com/jupyter-server/jupyter_server/pull/917) ([@rickwierenga](https://github.com/rickwierenga))
+- Add back support for kernel launch timeout pad [#910](https://github.com/jupyter-server/jupyter_server/pull/910) ([@CiprianAnton](https://github.com/CiprianAnton))
+
+### Maintenance and upkeep improvements
+
+- Test with client 8 updates [#992](https://github.com/jupyter-server/jupyter_server/pull/992) ([@blink1073](https://github.com/blink1073))
+- Backport PR #922: Improve logging of bare exceptions etc. [#926](https://github.com/jupyter-server/jupyter_server/pull/926) ([@thetorpedodog](https://github.com/thetorpedodog))
+- Fix handling of dev version [#913](https://github.com/jupyter-server/jupyter_server/pull/913) ([@blink1073](https://github.com/blink1073))
+- Fix owasp link [#908](https://github.com/jupyter-server/jupyter_server/pull/908) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-07-05&to=2022-09-26&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-07-05..2022-09-26&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-07-05..2022-09-26&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adavidbrochart+updated%3A2022-07-05..2022-09-26&type=Issues) | [@divyansshhh](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adivyansshhh+updated%3A2022-07-05..2022-09-26&type=Issues) | [@dlqqq](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adlqqq+updated%3A2022-07-05..2022-09-26&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aecharles+updated%3A2022-07-05..2022-09-26&type=Issues) | [@epignot](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aepignot+updated%3A2022-07-05..2022-09-26&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2022-07-05..2022-09-26&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksdev+updated%3A2022-07-05..2022-09-26&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-07-05..2022-09-26&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aminrk+updated%3A2022-07-05..2022-09-26&type=Issues) | [@thetorpedodog](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Athetorpedodog+updated%3A2022-07-05..2022-09-26&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Avidartf+updated%3A2022-07-05..2022-09-26&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2022-07-05..2022-09-26&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AZsailer+updated%3A2022-07-05..2022-09-26&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.18.1
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.18.0...65d779a12b6e4123de0767de6547e6cdf2d5e7e9))
@@ -18,8 +53,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-06-23&to=2022-07-05&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-06-23..2022-07-05&type=Issues) | [@Carreau](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3ACarreau+updated%3A2022-06-23..2022-07-05&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-06-23..2022-07-05&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adavidbrochart+updated%3A2022-06-23..2022-07-05&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aecharles+updated%3A2022-06-23..2022-07-05&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2022-06-23..2022-07-05&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-06-23..2022-07-05&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.23.0
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.21.0...16953940a16762329ef8f26c8c6d13a91defe0d3))
+
+### Enhancements made
+
+- Backport-1046: Pass kernel environment to `cwd_for_path` method (#1046) [#1051](https://github.com/jupyter-server/jupyter_server/pull/1051) ([@divyansshhh](https://github.com/divyansshhh))
+
+### Maintenance and upkeep improvements
+
+- \[1.x\] Switch to releaser v2 and update workflows [#1052](https://github.com/jupyter-server/jupyter_server/pull/1052) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-10-11&to=2022-11-07&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-10-11..2022-11-07&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-10-11..2022-11-07&type=Issues) | [@divyansshhh](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adivyansshhh+updated%3A2022-10-11..2022-11-07&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.21.0
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.19.1...2f529bf5d1f8c68a6b7193f474c9ba025111d743))
@@ -21,8 +41,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-09-27&to=2022-10-11&type=c))
 
 [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-09-27..2022-10-11&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-09-27..2022-10-11&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2022-09-27..2022-10-11&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.19.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bugs fixed
 
-- Backport PR #1212: Redact tokens, etc. in url parameters from request  logs [#1214](https://github.com/jupyter-server/jupyter_server/pull/1214) ([@blink1073](https://github.com/blink1073))
+- Backport PR #1212: Redact tokens, etc. in url parameters from request logs [#1214](https://github.com/jupyter-server/jupyter_server/pull/1214) ([@blink1073](https://github.com/blink1073))
 - Backport PR #1193: Fix get_loader returning None when load_jupyter_server_extension is not found (#1193) (#1199)Co-authored-by: Steven Silvester <steven.silvester@ieee.org> Co-authored-by: pre-commit-ci\[bot\] \<66853113+pre-commit-ci\[bot\]@users.noreply.github.com> [#1199](https://github.com/jupyter-server/jupyter_server/pull/1199) ([@cmd-ntrf](https://github.com/cmd-ntrf))
 
 ### Documentation improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.17.0
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.16.0...2b296099777d50aa86f67faf94d5cbfde906b169))
+
+### Enhancements made
+
+- Add the root_dir value to the logging message in case of non compliant preferred_dir [#804](https://github.com/jupyter-server/jupyter_server/pull/804) ([@echarles](https://github.com/echarles))
+
+### Bugs fixed
+
+- missing required arguments in utils.fetch [#798](https://github.com/jupyter-server/jupyter_server/pull/798) ([@minrk](https://github.com/minrk))
+
+### Maintenance and upkeep improvements
+
+- Add helper jobs for branch protection [#797](https://github.com/jupyter-server/jupyter_server/pull/797) ([@blink1073](https://github.com/blink1073))
+- [pre-commit.ci] pre-commit autoupdate [#793](https://github.com/jupyter-server/jupyter_server/pull/793) ([@pre-commit-ci[bot]](https://github.com/apps/pre-commit-ci))
+- Update branch references and links [#791](https://github.com/jupyter-server/jupyter_server/pull/791) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-03-29&to=2022-04-27&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-03-29..2022-04-27&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-03-29..2022-04-27&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adavidbrochart+updated%3A2022-03-29..2022-04-27&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aecharles+updated%3A2022-03-29..2022-04-27&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2022-03-29..2022-04-27&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksdev+updated%3A2022-03-29..2022-04-27&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-03-29..2022-04-27&type=Issues) | [@Wh1isper](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AWh1isper+updated%3A2022-03-29..2022-04-27&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AZsailer+updated%3A2022-03-29..2022-04-27&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.16.0
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.15.6...d32b887ae2c3b77fe3ae67ba79c3d3c6713c0d8a))
@@ -45,8 +71,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-03-16&to=2022-03-29&type=c))
 
 [@andreyvelich](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aandreyvelich+updated%3A2022-03-16..2022-03-29&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-03-16..2022-03-29&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-03-16..2022-03-29&type=Issues) | [@divyansshhh](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adivyansshhh+updated%3A2022-03-16..2022-03-29&type=Issues) | [@dleen](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adleen+updated%3A2022-03-16..2022-03-29&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Afcollonval+updated%3A2022-03-16..2022-03-29&type=Issues) | [@jhamet93](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ajhamet93+updated%3A2022-03-16..2022-03-29&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksdev+updated%3A2022-03-16..2022-03-29&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aminrk+updated%3A2022-03-16..2022-03-29&type=Issues) | [@rccern](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Arccern+updated%3A2022-03-16..2022-03-29&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2022-03-16..2022-03-29&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AZsailer+updated%3A2022-03-16..2022-03-29&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.15.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.17.1
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.17.0...v1.17.1)
+
+- Address security advisory [GHSA-q874-g24w-4q9g](https://github.com/jupyter-server/jupyter_server/security/advisories/GHSA-q874-g24w-4q9g).
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.17.0
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.16.0...2b296099777d50aa86f67faf94d5cbfde906b169))
@@ -27,8 +35,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-03-29&to=2022-04-27&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-03-29..2022-04-27&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-03-29..2022-04-27&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adavidbrochart+updated%3A2022-03-29..2022-04-27&type=Issues) | [@echarles](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Aecharles+updated%3A2022-03-29..2022-04-27&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2022-03-29..2022-04-27&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksdev+updated%3A2022-03-29..2022-04-27&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-03-29..2022-04-27&type=Issues) | [@Wh1isper](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AWh1isper+updated%3A2022-03-29..2022-04-27&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3AZsailer+updated%3A2022-03-29..2022-04-27&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.23.6
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.5...75bbefa82fa760b63e8ad8a9245f4a8d49503656))
+
+### Bugs fixed
+
+- Backport PR #1212: Redact tokens, etc. in url parameters from request  logs [#1214](https://github.com/jupyter-server/jupyter_server/pull/1214) ([@blink1073](https://github.com/blink1073))
+- Backport PR #1193: Fix get_loader returning None when load_jupyter_server_extension is not found (#1193) (#1199)Co-authored-by: Steven Silvester <steven.silvester@ieee.org> Co-authored-by: pre-commit-ci\[bot\] \<66853113+pre-commit-ci\[bot\]@users.noreply.github.com> [#1199](https://github.com/jupyter-server/jupyter_server/pull/1199) ([@cmd-ntrf](https://github.com/cmd-ntrf))
+
+### Documentation improvements
+
+- Update jupyterhub security link [#1200](https://github.com/jupyter-server/jupyter_server/pull/1200) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2023-01-12&to=2023-02-15&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2023-01-12..2023-02-15&type=Issues) | [@cmd-ntrf](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acmd-ntrf+updated%3A2023-01-12..2023-02-15&type=Issues) | [@codecov](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov+updated%3A2023-01-12..2023-02-15&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2023-01-12..2023-02-15&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksdev+updated%3A2023-01-12..2023-02-15&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2023-01-12..2023-02-15&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2023-01-12..2023-02-15&type=Issues) | [@xinliupitt](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Axinliupitt+updated%3A2023-01-12..2023-02-15&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.23.5
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.23.4...2ca800829c96dc60893dc83715282b7b8fd03d59))
@@ -17,8 +38,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-12-20&to=2023-01-12&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-12-20..2023-01-12&type=Issues) | [@Carreau](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3ACarreau+updated%3A2022-12-20..2023-01-12&type=Issues) | [@codecov](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov+updated%3A2022-12-20..2023-01-12&type=Issues) | [@meeseeksdev](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksdev+updated%3A2022-12-20..2023-01-12&type=Issues) | [@vidartf](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Avidartf+updated%3A2022-12-20..2023-01-12&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Awelcome+updated%3A2022-12-20..2023-01-12&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.23.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,42 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.18.0
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.17.1...a625db91efc4927c4b6fed4bf67ab995e479c36d))
+
+### Enhancements made
+
+- Show import error when faiing to load an extension [#878](https://github.com/jupyter-server/jupyter_server/pull/878) ([@minrk](https://github.com/minrk))
+
+### Bugs fixed
+
+- Fix gateway kernel shutdown [#874](https://github.com/jupyter-server/jupyter_server/pull/874) ([@kevin-bates](https://github.com/kevin-bates))
+
+### Maintenance and upkeep improvements
+
+- suppress tornado deprecation warnings [#882](https://github.com/jupyter-server/jupyter_server/pull/882) ([@minrk](https://github.com/minrk))
+- Normalize os_path [#886](https://github.com/jupyter-server/jupyter_server/pull/886) ([@martinRenou](https://github.com/martinRenou))
+- Fix lint [#867](https://github.com/jupyter-server/jupyter_server/pull/867) ([@blink1073](https://github.com/blink1073))
+- Fix sphinx 5.0 support [#865](https://github.com/jupyter-server/jupyter_server/pull/865) ([@blink1073](https://github.com/blink1073))
+
+### Documentation improvements
+
+- Add changelog entry for 1.17.1 [#871](https://github.com/jupyter-server/jupyter_server/pull/871) ([@blink1073](https://github.com/blink1073))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server/graphs/contributors?from=2022-06-07&to=2022-06-23&type=c))
+
+[@blink1073](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ablink1073+updated%3A2022-06-07..2022-06-23&type=Issues) | [@codecov-commenter](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Acodecov-commenter+updated%3A2022-06-07..2022-06-23&type=Issues) | [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Adavidbrochart+updated%3A2022-06-07..2022-06-23&type=Issues) | [@kevin-bates](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Akevin-bates+updated%3A2022-06-07..2022-06-23&type=Issues) | [@meeseeksmachine](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server+involves%3Ameeseeksmachine+updated%3A2022-06-07..2022-06-23&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.17.1
 
 ([Full Changelog](https://github.com/jupyter-server/jupyter_server/compare/v1.17.0...v1.17.1)
 
 - Address security advisory [GHSA-q874-g24w-4q9g](https://github.com/jupyter-server/jupyter_server/security/advisories/GHSA-q874-g24w-4q9g).
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.17.0
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Jupyter Server
 
-[![Build Status](https://github.com/jupyter/jupyter_server/workflows/CI/badge.svg?query=branch%3Amain++)](https://github.com/jupyter-server/jupyter_server/actions?query=branch%3Amain++)
-[![Documentation Status](https://readthedocs.org/projects/jupyter-server/badge/?version=latest)](http://jupyter-server.readthedocs.io/en/latest/?badge=latest)
+[![Build Status](https://github.com/jupyter/jupyter_server/workflows/CI/badge.svg?query=branch%3A1.x++)](https://github.com/jupyter-server/jupyter_server/actions?query=branch%3A1.x++)
+[![Documentation Status](https://readthedocs.org/projects/jupyter-server/badge/?version=stable)](http://jupyter-server.readthedocs.io/en/latest/?badge=stable)
 
 The Jupyter Server provides the backend (i.e. the core services, APIs, and REST endpoints) for Jupyter web applications like Jupyter notebook, JupyterLab, and Voila.
 
-For more information, read our [documentation here](http://jupyter-server.readthedocs.io/en/latest/?badge=latest).
+For more information, read our [documentation here](http://jupyter-server.readthedocs.io/en/stable/?badge=latest).
 
 ## Installation and Basic usage
 
@@ -22,7 +22,7 @@ If Jupyter Server is a dependency of your project/application, it is important t
 
 When a new minor version is released on PyPI, a branch for that version will be created in this repository, and the version of the main branch will be bumped to the next minor version number. That way, the main branch always reflects the latest un-released version.
 
-To see the changes between releases, checkout the [CHANGELOG](https://github.com/jupyter/jupyter_server/blob/main/CHANGELOG.md).
+To see the changes between releases, checkout the [CHANGELOG](https://github.com/jupyter/jupyter_server/blob/1.x/CHANGELOG.md).
 
 ## Usage - Running Jupyter Server
 
@@ -34,7 +34,7 @@ Launch with:
 
 ### Testing
 
-See [CONTRIBUTING](https://github.com/jupyter-server/jupyter_server/blob/main/CONTRIBUTING.rst#running-tests).
+See [CONTRIBUTING](https://github.com/jupyter-server/jupyter_server/blob/1.x/CONTRIBUTING.rst#running-tests).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Jupyter Server
 
-[![Build Status](https://github.com/jupyter/jupyter_server/workflows/CI/badge.svg?query=branch%3A1.x++)](https://github.com/jupyter-server/jupyter_server/actions?query=branch%3A1.x++)
-[![Documentation Status](https://readthedocs.org/projects/jupyter-server/badge/?version=stable)](http://jupyter-server.readthedocs.io/en/latest/?badge=stable)
-
 The Jupyter Server provides the backend (i.e. the core services, APIs, and REST endpoints) for Jupyter web applications like Jupyter notebook, JupyterLab, and Voila.
 
 For more information, read our [documentation here](http://jupyter-server.readthedocs.io/en/stable/?badge=latest).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,9 @@
 
 The recommended way to make a release is to use [`jupyter_releaser`](https://github.com/jupyter-server/jupyter_releaser#checklist-for-adoption).
 
+Note that we must use manual versions since Jupyter Releaser does not
+yet support "next" or "patch" when dev versions are used.
+
 ## Manual Release
 
 To create a manual release, perform the following steps:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
 # Jupyter Server Docs Sources
 
-Read [this page](https://jupyter-server.readthedocs.io/en/latest/contributors/contributing.html#building-the-docs) to build the docs.
+Read [this page](https://jupyter-server.readthedocs.io/en/stable/contributors/contributing.html#building-the-docs) to build the docs.

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,3 +1,6 @@
+# needed because m2r uses deprecated APIs
+# m2r is depended on by sphinxcontrib-openapi
+docutils<0.19
 ipykernel
 jinja2
 jupyter_client

--- a/docs/doc-requirements.txt
+++ b/docs/doc-requirements.txt
@@ -1,6 +1,8 @@
 ipykernel
 jinja2
 jupyter_client
+jupyter_server
+mistune<1.0.0
 myst-parser
 nbformat
 prometheus_client

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.23.6"
+__version__ = "1.24.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.20.0.dev0"
+__version__ = "1.19.1"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.14.0.dev0"
+__version__ = "1.18.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.21.0"
+__version__ = "1.22.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.24.0.dev0"
+__version__ = "1.23.2"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.23.3"
+__version__ = "1.24.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.19.0.dev0"
+__version__ = "1.19.0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.22.0.dev0"
+__version__ = "1.23.0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.23.1"
+__version__ = "1.24.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -117,7 +117,7 @@ version = f"{version_parsed.major}.{version_parsed.minor}"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.24.0.dev0"
+__version__ = "1.23.5"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.23.0"
+__version__ = "1.24.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.24.0.dev0"
+__version__ = "1.23.4"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.24.0.dev0"
+__version__ = "1.23.1"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.24.0.dev0"
+__version__ = "1.23.6"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.19.1"
+__version__ = "1.20.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.20.0.dev0"
+__version__ = "1.21.0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.24.0.dev0"
+__version__ = "1.24.0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.19.0.dev0"
+__version__ = "1.18.1"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.19.0"
+__version__ = "1.20.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.18.1"
+__version__ = "1.19.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.17.1"
+__version__ = "1.18.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.23.2"
+__version__ = "1.24.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.18.0"
+__version__ = "1.19.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.18.0.dev0"
+__version__ = "1.18.0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.24.0.dev0"
+__version__ = "1.23.3"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.18.0.dev0"
+__version__ = "1.17.1"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.23.5"
+__version__ = "1.24.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ import os.path as osp
 import shutil
 import sys
 
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 HERE = osp.abspath(osp.dirname(__file__))
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ github_project_url = "https://github.com/jupyter/jupyter_server"
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-__version__ = "1.23.4"
+__version__ = "1.24.0.dev0"
 # The short X.Y version.
 version_parsed = parse_version(__version__)
 version = f"{version_parsed.major}.{version_parsed.minor}"

--- a/docs/source/developers/extensions.rst
+++ b/docs/source/developers/extensions.rst
@@ -5,7 +5,7 @@ Server Extensions
 A Jupyter Server extension is typically a module or package that extends to Server’s REST API/endpoints—i.e. adds extra request handlers to Server’s Tornado Web Application.
 
 You can check some simple examples on the `examples folder
-<https://github.com/jupyter/jupyter_server/tree/main/examples/simple>`_ in the GitHub jupyter_server repository.
+<https://github.com/jupyter/jupyter_server/tree/1.x/examples/simple>`_ in the GitHub jupyter_server repository.
 
 Authoring a basic server extension
 ==================================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ Jupyter Server is the backendâ€”the core services, APIs, and `REST endpoints`_â€
 
 .. _Tornado: https://www.tornadoweb.org/en/stable/
 .. _Jupyter Notebook: https://github.com/jupyter/notebook
-.. _REST endpoints: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyter_server/main/jupyter_server/services/api/api.yaml
+.. _REST endpoints: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyter/jupyter_server/1.x/jupyter_server/services/api/api.yaml
 
 Who's this for?
 ---------------

--- a/docs/source/operators/public-server.rst
+++ b/docs/source/operators/public-server.rst
@@ -180,7 +180,7 @@ compliant self-signed certificate that will not raise warnings, it is possible
 certificate and follow the steps in :ref:`using-lets-encrypt` to set up a
 public server.
 
-.. _OWASP: https://www.owasp.org/index.php/Main_Page
+.. _OWASP: https://owasp.org/sitemap/
 .. _tutorial: https://arstechnica.com/information-technology/2009/12/how-to-get-set-with-a-secure-sertificate-for-free/
 
 .. _jupyter_public_server:

--- a/docs/source/operators/public-server.rst
+++ b/docs/source/operators/public-server.rst
@@ -364,7 +364,7 @@ or in :file:`jupyter_notebook_config.py`:
 
    .. code-block:: python
 
-      c.GatewayClient.url = http://my-gateway-server:8888
+      c.GatewayClient.url = 'http://my-gateway-server:8888'
 
 When provided, all kernel specifications will be retrieved from the specified Gateway server and all
 kernels will be managed by that server.  This option enables the ability to target kernel processes

--- a/docs/source/operators/public-server.rst
+++ b/docs/source/operators/public-server.rst
@@ -31,7 +31,7 @@ This document describes how you can
     To use JupyterHub, you need a Unix server (typically Linux) running
     somewhere that is accessible to your users on a network. This may run over
     the public internet, but doing so introduces additional
-    `security concerns <https://jupyterhub.readthedocs.io/en/latest/getting-started/security-basics.html>`_.
+    `security concerns <https://jupyterhub.readthedocs.io/en/stable/reference/websecurity.html>`_.
 
 
 

--- a/examples/authorization/jupyter_nbclassic_readonly_config.py
+++ b/examples/authorization/jupyter_nbclassic_readonly_config.py
@@ -11,4 +11,4 @@ class ReadOnly(Authorizer):
         return True
 
 
-c.ServerApp.authorizer_class = ReadOnly
+c.ServerApp.authorizer_class = ReadOnly  # type:ignore[name-defined]

--- a/examples/authorization/jupyter_nbclassic_rw_config.py
+++ b/examples/authorization/jupyter_nbclassic_rw_config.py
@@ -11,4 +11,4 @@ class ReadWriteOnly(Authorizer):
         return True
 
 
-c.ServerApp.authorizer_class = ReadWriteOnly
+c.ServerApp.authorizer_class = ReadWriteOnly  # type:ignore[name-defined]

--- a/examples/authorization/jupyter_temporary_config.py
+++ b/examples/authorization/jupyter_temporary_config.py
@@ -11,4 +11,4 @@ class TemporaryServerPersonality(Authorizer):
         return True
 
 
-c.ServerApp.authorizer_class = TemporaryServerPersonality
+c.ServerApp.authorizer_class = TemporaryServerPersonality  # type:ignore[name-defined]

--- a/examples/simple/jupyter_server_config.py
+++ b/examples/simple/jupyter_server_config.py
@@ -3,4 +3,6 @@
 # Application(SingletonConfigurable) configuration
 # ------------------------------------------------------------------------------
 # The date format used by logging formatters for %(asctime)s
-c.Application.log_datefmt = "%Y-%m-%d %H:%M:%S Simple_Extensions_Example"
+c.Application.log_datefmt = (  # type:ignore[name-defined]
+    "%Y-%m-%d %H:%M:%S Simple_Extensions_Example"
+)

--- a/examples/simple/jupyter_simple_ext11_config.py
+++ b/examples/simple/jupyter_simple_ext11_config.py
@@ -1,1 +1,1 @@
-c.SimpleApp11.ignore_js = True
+c.SimpleApp11.ignore_js = True  # type:ignore[name-defined]

--- a/examples/simple/jupyter_simple_ext1_config.py
+++ b/examples/simple/jupyter_simple_ext1_config.py
@@ -1,4 +1,4 @@
-c.SimpleApp1.configA = "ConfigA from file"
-c.SimpleApp1.configB = "ConfigB from file"
-c.SimpleApp1.configC = "ConfigC from file"
-c.SimpleApp1.configD = "ConfigD from file"
+c.SimpleApp1.configA = "ConfigA from file"  # type:ignore[name-defined]
+c.SimpleApp1.configB = "ConfigB from file"  # type:ignore[name-defined]
+c.SimpleApp1.configC = "ConfigC from file"  # type:ignore[name-defined]
+c.SimpleApp1.configD = "ConfigD from file"  # type:ignore[name-defined]

--- a/examples/simple/jupyter_simple_ext2_config.py
+++ b/examples/simple/jupyter_simple_ext2_config.py
@@ -1,1 +1,1 @@
-c.SimpleApp2.configD = "ConfigD from file"
+c.SimpleApp2.configD = "ConfigD from file"  # type:ignore[name-defined]

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 22, 0, ".dev", "0")
+version_info = (1, 23, 0, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 24, 0, ".dev", "0")
+version_info = (1, 23, 5, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 20, 0, ".dev", "0")
+version_info = (1, 21, 0, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 24, 0, ".dev", "0")
+version_info = (1, 24, 0, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 17, 0, "", "")
+version_info = (1, 18, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 18, 1, "", "")
+version_info = (1, 19, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 24, 0, ".dev", "0")
+version_info = (1, 23, 4, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 24, 0, ".dev", "0")
+version_info = (1, 23, 2, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 23, 3, "", "")
+version_info = (1, 24, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 16, 1, ".dev", "0")
+version_info = (1, 17, 0, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 18, 0, "", "")
+version_info = (1, 19, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 24, 0, ".dev", "0")
+version_info = (1, 23, 6, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 23, 5, "", "")
+version_info = (1, 24, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 18, 0, ".dev", "0")
+version_info = (1, 17, 1, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 17, 1, "", "")
+version_info = (1, 18, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 19, 0, ".dev", "0")
+version_info = (1, 19, 0, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 21, 0, "", "")
+version_info = (1, 22, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 23, 6, "", "")
+version_info = (1, 24, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 20, 0, ".dev", "0")
+version_info = (1, 19, 1, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 24, 0, ".dev", "0")
+version_info = (1, 23, 1, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 23, 4, "", "")
+version_info = (1, 24, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 23, 2, "", "")
+version_info = (1, 24, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 19, 0, ".dev", "0")
+version_info = (1, 18, 1, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 23, 1, "", "")
+version_info = (1, 24, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 24, 0, ".dev", "0")
+version_info = (1, 23, 3, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 18, 0, ".dev", "0")
+version_info = (1, 18, 0, "", "")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 23, 0, "", "")
+version_info = (1, 24, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 19, 1, "", "")
+version_info = (1, 20, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/_version.py
+++ b/jupyter_server/_version.py
@@ -2,5 +2,5 @@
 store the current version info of the server.
 
 """
-version_info = (1, 19, 0, "", "")
+version_info = (1, 20, 0, ".dev", "0")
 __version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])

--- a/jupyter_server/auth/decorator.py
+++ b/jupyter_server/auth/decorator.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional, Union
 from tornado.log import app_log
 from tornado.web import HTTPError
 
-from .utils import HTTP_METHOD_TO_AUTH_ACTION, warn_disabled_authorization
+from .utils import HTTP_METHOD_TO_AUTH_ACTION
 
 
 def authorized(
@@ -57,18 +57,13 @@ def authorized(
             if not user:
                 app_log.warning("Attempting to authorize request without authentication!")
                 raise HTTPError(status_code=403, log_message=message)
-
-            # Handle the case where an authorizer wasn't attached to the handler.
-            if not self.authorizer:
-                warn_disabled_authorization()
-                return method(self, *args, **kwargs)
-
-            # Only return the method if the action is authorized.
+            # If the user is allowed to do this action,
+            # call the method.
             if self.authorizer.is_authorized(self, user, action, resource):
                 return method(self, *args, **kwargs)
-
-            # Raise an exception if the method wasn't returned (i.e. not authorized)
-            raise HTTPError(status_code=403, log_message=message)
+            # else raise an exception.
+            else:
+                raise HTTPError(status_code=403, log_message=message)
 
         return inner
 

--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -83,7 +83,7 @@ class LoginHandler(JupyterHandler):
             elif self.token and self.token == typed_password:
                 self.set_login_cookie(self, uuid.uuid4().hex)
                 if new_password and self.settings.get("allow_password_change"):
-                    config_dir = self.settings.get("config_dir")
+                    config_dir = self.settings.get("config_dir", "")
                     config_file = os.path.join(config_dir, "jupyter_server_config.json")
                     set_password(new_password, config_file=config_file)
                     self.log.info("Wrote hashed password to %s" % config_file)

--- a/jupyter_server/auth/security.py
+++ b/jupyter_server/auth/security.py
@@ -64,9 +64,9 @@ def passwd(passphrase=None, algorithm="argon2"):
             time_cost=10,
             parallelism=8,
         )
-        h = ph.hash(passphrase)
+        h_ph = ph.hash(passphrase)
 
-        return ":".join((algorithm, h))
+        return ":".join((algorithm, h_ph))
 
     h = hashlib.new(algorithm)
     salt = ("%0" + str(salt_len) + "x") % random.getrandbits(4 * salt_len)

--- a/jupyter_server/auth/utils.py
+++ b/jupyter_server/auth/utils.py
@@ -39,9 +39,9 @@ def get_regex_to_resource_map():
     from jupyter_server.serverapp import JUPYTER_SERVICE_HANDLERS
 
     modules = []
-    for mod in JUPYTER_SERVICE_HANDLERS.values():
-        if mod:
-            modules.extend(mod)
+    for mod_name in JUPYTER_SERVICE_HANDLERS.values():
+        if mod_name:
+            modules.extend(mod_name)
     resource_map = {}
     for handler_module in modules:
         mod = importlib.import_module(handler_module)

--- a/jupyter_server/auth/utils.py
+++ b/jupyter_server/auth/utils.py
@@ -8,16 +8,11 @@ import warnings
 
 
 def warn_disabled_authorization():
+    """DEPRECATED, does nothing"""
     warnings.warn(
-        "The Tornado web application does not have an 'authorizer' defined "
-        "in its settings. In future releases of jupyter_server, this will "
-        "be a required key for all subclasses of `JupyterHandler`. For an "
-        "example, see the jupyter_server source code for how to "
-        "add an authorizer to the tornado settings: "
-        "https://github.com/jupyter-server/jupyter_server/blob/"
-        "653740cbad7ce0c8a8752ce83e4d3c2c754b13cb/jupyter_server/serverapp.py"
-        "#L234-L256",
-        FutureWarning,
+        "jupyter_server.auth.utils.warn_disabled_authorization is deprecated",
+        DeprecationWarning,
+        stacklevel=2,
     )
 
 

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -95,7 +95,7 @@ class AuthenticatedHandler(web.RequestHandler):
                 # tornado raise Exception (not a subclass)
                 # if method is unsupported (websocket and Access-Control-Allow-Origin
                 # for example, so just ignore)
-                self.log.debug(e)
+                self.log.exception("Could not set default headers: %s", e)
 
     def force_clear_cookie(self, name, path="/", domain=None):
         """Deletes the cookie with the given name.
@@ -646,7 +646,7 @@ class APIHandler(JupyterHandler):
                 reply["message"] = "Unhandled error"
                 reply["reason"] = None
                 reply["traceback"] = "".join(traceback.format_exception(*exc_info))
-        self.log.warning(reply["message"])
+        self.log.warning("wrote error: %r", reply["message"])
         self.finish(json.dumps(reply))
 
     def get_current_user(self):

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -193,7 +193,23 @@ class AuthenticatedHandler(web.RequestHandler):
 
     @property
     def authorizer(self):
-        return self.settings.get("authorizer")
+        if "authorizer" not in self.settings:
+            warnings.warn(
+                "The Tornado web application does not have an 'authorizer' defined "
+                "in its settings. In future releases of jupyter_server, this will "
+                "be a required key for all subclasses of `JupyterHandler`. For an "
+                "example, see the jupyter_server source code for how to "
+                "add an authorizer to the tornado settings: "
+                "https://github.com/jupyter-server/jupyter_server/blob/"
+                "653740cbad7ce0c8a8752ce83e4d3c2c754b13cb/jupyter_server/serverapp.py"
+                "#L234-L256",
+            )
+            from jupyter_server.auth import AllowAllAuthorizer
+
+            self.settings["authorizer"] = AllowAllAuthorizer(
+                config=self.settings.get("config", None)
+            )
+        return self.settings["authorizer"]
 
 
 class JupyterHandler(AuthenticatedHandler):

--- a/jupyter_server/base/zmqhandlers.py
+++ b/jupyter_server/base/zmqhandlers.py
@@ -19,8 +19,6 @@ from jupyter_client.session import Session
 from tornado import ioloop, web
 from tornado.websocket import WebSocketHandler
 
-from jupyter_server.auth.utils import warn_disabled_authorization
-
 from .handlers import JupyterHandler
 
 
@@ -321,10 +319,7 @@ class AuthenticatedZMQStreamHandler(ZMQStreamHandler, JupyterHandler):
             raise web.HTTPError(403)
 
         # authorize the user.
-        if not self.authorizer:
-            # Warn if there is not authorizer.
-            warn_disabled_authorization()
-        elif not self.authorizer.is_authorized(self, user, "execute", "kernels"):
+        if not self.authorizer.is_authorized(self, user, "execute", "kernels"):
             raise web.HTTPError(403)
 
         if self.get_argument("session_id", False):

--- a/jupyter_server/config_manager.py
+++ b/jupyter_server/config_manager.py
@@ -95,7 +95,7 @@ class BaseJSONConfigManager(LoggingConfigurable):
             section_name,
             "\n\t".join(paths),
         )
-        data = {}
+        data: dict = {}
         for path in paths:
             if os.path.isfile(path):
                 with open(path, encoding="utf-8") as f:

--- a/jupyter_server/extension/application.py
+++ b/jupyter_server/extension/application.py
@@ -137,7 +137,7 @@ class ExtensionApp(JupyterApp):
     # A useful class property that subclasses can override to
     # configure the underlying Jupyter Server when this extension
     # is launched directly (using its `launch_instance` method).
-    serverapp_config = {}
+    serverapp_config: dict = {}
 
     # Some subclasses will likely override this trait to flip
     # the default value to False if they don't offer a browser
@@ -165,7 +165,7 @@ class ExtensionApp(JupyterApp):
     # file, jupyter_{name}_config.
     # This should also match the jupyter subcommand used to launch
     # this extension from the CLI, e.g. `jupyter {name}`.
-    name = None
+    name = "ExtensionApp"
 
     @classmethod
     def get_extension_package(cls):
@@ -318,7 +318,7 @@ class ExtensionApp(JupyterApp):
             handler = handler_items[1]
 
             # Get handler kwargs, if given
-            kwargs = {}
+            kwargs: dict = {}
             if issubclass(handler, ExtensionHandlerMixin):
                 kwargs["name"] = self.name
 

--- a/jupyter_server/extension/handler.py
+++ b/jupyter_server/extension/handler.py
@@ -1,3 +1,5 @@
+from typing import no_type_check
+
 from jinja2.exceptions import TemplateNotFound
 
 from jupyter_server.base.handlers import FileFindHandler
@@ -8,6 +10,7 @@ class ExtensionHandlerJinjaMixin:
     template rendering.
     """
 
+    @no_type_check
     def get_template(self, name):
         """Return the jinja template object for a given name"""
         try:
@@ -33,17 +36,17 @@ class ExtensionHandlerMixin:
 
     @property
     def extensionapp(self):
-        return self.settings[self.name]
+        return self.settings[self.name]  # type:ignore[attr-defined]
 
     @property
     def serverapp(self):
         key = "serverapp"
-        return self.settings[key]
+        return self.settings[key]  # type:ignore[attr-defined]
 
     @property
     def log(self):
         if not hasattr(self, "name"):
-            return super().log
+            return super().log  # type:ignore[misc]
         # Attempt to pull the ExtensionApp's log, otherwise fall back to ServerApp.
         try:
             return self.extensionapp.log
@@ -52,15 +55,15 @@ class ExtensionHandlerMixin:
 
     @property
     def config(self):
-        return self.settings[f"{self.name}_config"]
+        return self.settings[f"{self.name}_config"]  # type:ignore[attr-defined]
 
     @property
     def server_config(self):
-        return self.settings["config"]
+        return self.settings["config"]  # type:ignore[attr-defined]
 
     @property
-    def base_url(self):
-        return self.settings.get("base_url", "/")
+    def base_url(self) -> str:
+        return self.settings.get("base_url", "/")  # type:ignore[attr-defined]
 
     @property
     def static_url_prefix(self):
@@ -68,7 +71,7 @@ class ExtensionHandlerMixin:
 
     @property
     def static_path(self):
-        return self.settings[f"{self.name}_static_paths"]
+        return self.settings[f"{self.name}_static_paths"]  # type:ignore[attr-defined]
 
     def static_url(self, path, include_host=None, **kwargs):
         """Returns a static URL for the given relative static file path.
@@ -89,9 +92,9 @@ class ExtensionHandlerMixin:
         """
         key = f"{self.name}_static_paths"
         try:
-            self.require_setting(key, "static_url")
+            self.require_setting(key, "static_url")  # type:ignore[attr-defined]
         except Exception as e:
-            if key in self.settings:
+            if key in self.settings:  # type:ignore[attr-defined]
                 raise Exception(
                     "This extension doesn't have any static paths listed. Check that the "
                     "extension's `static_paths` trait is set."
@@ -99,13 +102,15 @@ class ExtensionHandlerMixin:
             else:
                 raise e
 
-        get_url = self.settings.get("static_handler_class", FileFindHandler).make_static_url
+        get_url = self.settings.get(  # type:ignore[attr-defined]
+            "static_handler_class", FileFindHandler
+        ).make_static_url
 
         if include_host is None:
             include_host = getattr(self, "include_host", False)
 
         if include_host:
-            base = self.request.protocol + "://" + self.request.host
+            base = self.request.protocol + "://" + self.request.host  # type:ignore[attr-defined]
         else:
             base = ""
 

--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -175,10 +175,10 @@ class ExtensionPackage(HasTraits):
         self._extension_points = {}
         try:
             self._module, self._metadata = get_metadata(name)
-        except ImportError:
+        except ImportError as e:
             raise ExtensionModuleNotFound(
-                "The module '{name}' could not be found. Are you "
-                "sure the extension is installed?".format(name=name)
+                "The module '{name}' could not be found ({e}). Are you "
+                "sure the extension is installed?".format(name=name, e=e)
             )
         # Create extension point interfaces for each extension path.
         for m in self._metadata:

--- a/jupyter_server/extension/manager.py
+++ b/jupyter_server/extension/manager.py
@@ -167,7 +167,7 @@ class ExtensionPackage(HasTraits):
         self._linked_points = {}
         super().__init__(*args, **kwargs)
 
-    _linked_points = {}
+    _linked_points: dict = {}
 
     @validate_trait("name")
     def _validate_name(self, proposed):

--- a/jupyter_server/extension/utils.py
+++ b/jupyter_server/extension/utils.py
@@ -26,19 +26,24 @@ def get_loader(obj, logger=None):
     underscore prefix.
     """
     try:
-        func = getattr(obj, "_load_jupyter_server_extension")  # noqa B009
+        return getattr(obj, "_load_jupyter_server_extension")  # noqa B009
     except AttributeError:
-        func = getattr(obj, "load_jupyter_server_extension", None)
-        warnings.warn(
-            "A `_load_jupyter_server_extension` function was not "
-            "found in {name!s}. Instead, a `load_jupyter_server_extension` "
-            "function was found and will be used for now. This function "
-            "name will be deprecated in future releases "
-            "of Jupyter Server.".format(name=obj),
-            DeprecationWarning,
-        )
-    except Exception:
-        raise ExtensionLoadingError("_load_jupyter_server_extension function was not found.")
+        pass
+
+    try:
+        func = getattr(obj, "load_jupyter_server_extension")  # noqa B009
+    except AttributeError:
+        msg = "_load_jupyter_server_extension function was not found."
+        raise ExtensionLoadingError(msg) from None
+
+    warnings.warn(
+        "A `_load_jupyter_server_extension` function was not "
+        "found in {name!s}. Instead, a `load_jupyter_server_extension` "
+        "function was found and will be used for now. This function "
+        "name will be deprecated in future releases "
+        "of Jupyter Server.".format(name=obj),
+        DeprecationWarning,
+    )
     return func
 
 

--- a/jupyter_server/files/handlers.py
+++ b/jupyter_server/files/handlers.py
@@ -4,6 +4,7 @@
 import json
 import mimetypes
 from base64 import decodebytes
+from typing import List
 
 from tornado import web
 
@@ -57,7 +58,7 @@ class FilesHandler(JupyterHandler):
 
         model = await ensure_async(cm.get(path, type="file", content=include_body))
 
-        if self.get_argument("download", False):
+        if self.get_argument("download", None):
             self.set_attachment_header(name)
 
         # get mimetype from filename
@@ -91,4 +92,4 @@ class FilesHandler(JupyterHandler):
             self.flush()
 
 
-default_handlers = []
+default_handlers: List[JupyterHandler] = []

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -416,7 +416,14 @@ class GatewayClient(SingletonConfigurable):
         if len(self._static_args) == 0:
             self.init_static_args()
 
-        kwargs.update(self._static_args)
+        for arg, static_value in self._static_args.items():
+            if arg == "headers":
+                given_value = kwargs.setdefault(arg, {})
+                if isinstance(given_value, dict):
+                    given_value.update(static_value)
+            else:
+                kwargs[arg] = static_value
+
         return kwargs
 
 

--- a/jupyter_server/gateway/gateway_client.py
+++ b/jupyter_server/gateway/gateway_client.py
@@ -506,9 +506,19 @@ async def gateway_request(endpoint: str, **kwargs: ty.Any) -> HTTPResponse:
     # NOTE: We do this here since this handler is called during the server's startup and subsequent refreshes
     # of the tree view.
     except HTTPClientError as e:
+        error_reason = f"Exception while attempting to connect to Gateway server url '{GatewayClient.instance().url}'"
+        error_message = str(e)
+        if e.response:
+            try:
+                error_payload = json.loads(e.response.body)
+                error_reason = error_payload.get("reason") or error_reason
+                error_message = error_payload.get("message") or error_message
+            except json.decoder.JSONDecodeError:
+                error_reason = e.response.body.decode()
+
         raise web.HTTPError(
             e.code,
-            f"Error attempting to connect to Gateway server url '{GatewayClient.instance().url}'.  "
+            f"Error from Gateway: [{error_message}] {error_reason}. "
             "Ensure gateway url is valid and the Gateway instance is running.",
         ) from e
     except ConnectionError as e:

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -326,7 +326,8 @@ class GatewayKernelManager(AsyncKernelManager):
         self.kernels_url = url_path_join(
             GatewayClient.instance().url, GatewayClient.instance().kernels_endpoint
         )
-        self.kernel_url = self.kernel = self.kernel_id = None
+        self.kernel_url: str
+        self.kernel = self.kernel_id = None
         # simulate busy/activity markers:
         self.execution_state = self.last_activity = None
 

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -92,7 +92,7 @@ class GatewayMappingKernelManager(AsyncMappingKernelManager):
             The uuid of the kernel.
         """
         model = None
-        km = self.get_kernel(kernel_id)
+        km = self.get_kernel(str(kernel_id))
         if km:
             model = km.kernel
         return model
@@ -166,13 +166,14 @@ class GatewayMappingKernelManager(AsyncMappingKernelManager):
 
     async def shutdown_all(self, now=False):
         """Shutdown all kernels."""
-        for kernel_id in self._kernels:
+        kids = list(self._kernels)
+        for kernel_id in kids:
             km = self.get_kernel(kernel_id)
             await km.shutdown_kernel(now=now)
             self.remove_kernel(kernel_id)
 
     async def cull_kernels(self):
-        """Override cull_kernels so we can be sure their state is current."""
+        """Override cull_kernels, so we can be sure their state is current."""
         await self.list_kernels()
         await super().cull_kernels()
 
@@ -295,7 +296,7 @@ class GatewaySessionManager(SessionManager):
     kernel_manager = Instance("jupyter_server.gateway.managers.GatewayMappingKernelManager")
 
     async def kernel_culled(self, kernel_id):
-        """Checks if the kernel is still considered alive and returns true if its not found."""
+        """Checks if the kernel is still considered alive and returns true if it's not found."""
         kernel = None
         try:
             km = self.kernel_manager.get_kernel(kernel_id)
@@ -387,7 +388,7 @@ class GatewayKernelManager(AsyncKernelManager):
             if isinstance(self.parent, AsyncMappingKernelManager):
                 # Update connections only if there's a mapping kernel manager parent for
                 # this kernel manager.  The current kernel manager instance may not have
-                # an parent instance if, say, a server extension is using another application
+                # a parent instance if, say, a server extension is using another application
                 # (e.g., papermill) that uses a KernelManager instance directly.
                 self.parent._kernel_connections[self.kernel_id] = int(model["connections"])
 
@@ -448,8 +449,14 @@ class GatewayKernelManager(AsyncKernelManager):
 
         if self.has_kernel:
             self.log.debug("Request shutdown kernel at: %s", self.kernel_url)
-            response = await gateway_request(self.kernel_url, method="DELETE")
-            self.log.debug("Shutdown kernel response: %d %s", response.code, response.reason)
+            try:
+                response = await gateway_request(self.kernel_url, method="DELETE")
+                self.log.debug("Shutdown kernel response: %d %s", response.code, response.reason)
+            except web.HTTPError as error:
+                if error.status_code == 404:
+                    self.log.debug("Shutdown kernel response: kernel not found (ignored)")
+                else:
+                    raise
 
     async def restart_kernel(self, **kw):
         """Restarts a kernel via HTTP."""
@@ -518,7 +525,7 @@ class ChannelQueue(Queue):
 
     @staticmethod
     def serialize_datetime(dt):
-        if isinstance(dt, (datetime.datetime)):
+        if isinstance(dt, datetime.datetime):
             return dt.timestamp()
         return None
 
@@ -595,7 +602,7 @@ class GatewayKernelClient(AsyncKernelClient):
         """Starts the channels for this kernel.
 
         For this class, we establish a websocket connection to the destination
-        and setup the channel-based queues on which applicable messages will
+        and set up the channel-based queues on which applicable messages will
         be posted.
         """
 
@@ -606,10 +613,11 @@ class GatewayKernelClient(AsyncKernelClient):
             "channels",
         )
         # Gather cert info in case where ssl is desired...
-        ssl_options = {}
-        ssl_options["ca_certs"] = GatewayClient.instance().ca_certs
-        ssl_options["certfile"] = GatewayClient.instance().client_cert
-        ssl_options["keyfile"] = GatewayClient.instance().client_key
+        ssl_options = {
+            "ca_certs": GatewayClient.instance().ca_certs,
+            "certfile": GatewayClient.instance().client_cert,
+            "keyfile": GatewayClient.instance().client_key,
+        }
 
         self.channel_socket = websocket.create_connection(
             ws_url,
@@ -720,7 +728,7 @@ class GatewayKernelClient(AsyncKernelClient):
                 self._channel_queues[channel].put_nowait(response_message)
 
         except websocket.WebSocketConnectionClosedException:
-            pass  # websocket closure most likely due to shutdown
+            pass  # websocket closure most likely due to shut down
 
         except BaseException as be:
             if not self._channels_stopped:

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -498,12 +498,14 @@ KernelManagerABC.register(GatewayKernelManager)
 class ChannelQueue(Queue):
 
     channel_name: Optional[str] = None
+    response_router_finished: bool
 
     def __init__(self, channel_name: str, channel_socket: websocket.WebSocket, log: Logger):
         super().__init__()
         self.channel_name = channel_name
         self.channel_socket = channel_socket
         self.log = log
+        self.response_router_finished = False
 
     async def _async_get(self, timeout=None):
         if timeout is None:
@@ -516,6 +518,8 @@ class ChannelQueue(Queue):
             try:
                 return self.get(block=False)
             except Empty:
+                if self.response_router_finished:
+                    raise RuntimeError("Response router had finished")
                 if monotonic() > end_time:
                     raise
                 await asyncio.sleep(0)
@@ -597,19 +601,21 @@ class GatewayKernelClient(AsyncKernelClient):
 
     # flag for whether execute requests should be allowed to call raw_input:
     allow_stdin = False
-    _channels_stopped = False
-    _channel_queues: Optional[dict] = {}
+    _channels_stopped: bool
+    _channel_queues: Optional[Dict[str, ChannelQueue]]
     _control_channel: Optional[ChannelQueue]
     _hb_channel: Optional[ChannelQueue]
     _stdin_channel: Optional[ChannelQueue]
     _iopub_channel: Optional[ChannelQueue]
     _shell_channel: Optional[ChannelQueue]
 
-    def __init__(self, **kwargs):
+    def __init__(self, kernel_id, **kwargs):
         super().__init__(**kwargs)
-        self.kernel_id = kwargs["kernel_id"]
+        self.kernel_id = kernel_id
         self.channel_socket: Optional[websocket.WebSocket] = None
         self.response_router: Optional[Thread] = None
+        self._channels_stopped = False
+        self._channel_queues = {}
 
     # --------------------------------------------------------------------------
     # Channel management methods
@@ -642,12 +648,13 @@ class GatewayKernelClient(AsyncKernelClient):
             enable_multithread=True,
             sslopt=ssl_options,
         )
-        self.response_router = Thread(target=self._route_responses)
-        self.response_router.start()
 
         await ensure_async(
             super().start_channels(shell=shell, iopub=iopub, stdin=stdin, hb=hb, control=control)
         )
+
+        self.response_router = Thread(target=self._route_responses)
+        self.response_router.start()
 
     def stop_channels(self):
         """Stops all the running channels for this kernel.
@@ -750,6 +757,11 @@ class GatewayKernelClient(AsyncKernelClient):
         except BaseException as be:
             if not self._channels_stopped:
                 self.log.warning(f"Unexpected exception encountered ({be})")
+
+        # Notify channel queues that this thread had finished and no more messages are being received
+        assert self._channel_queues is not None
+        for channel_queue in self._channel_queues.values():
+            channel_queue.response_router_finished = True
 
         self.log.debug("Response router thread exiting...")
 

--- a/jupyter_server/gateway/managers.py
+++ b/jupyter_server/gateway/managers.py
@@ -436,7 +436,12 @@ class GatewayKernelManager(AsyncKernelManager):
 
             json_body = json_encode({"name": kernel_name, "env": kernel_env})
 
-            response = await gateway_request(self.kernels_url, method="POST", body=json_body)
+            response = await gateway_request(
+                self.kernels_url,
+                method="POST",
+                headers={"Content-Type": "application/json"},
+                body=json_body,
+            )
             self.kernel = json_decode(response.body)
             self.kernel_id = self.kernel["id"]
             self.kernel_url = url_path_join(self.kernels_url, url_escape(str(self.kernel_id)))
@@ -467,7 +472,12 @@ class GatewayKernelManager(AsyncKernelManager):
             assert self.kernel_url is not None
             kernel_url = self.kernel_url + "/restart"
             self.log.debug("Request restart kernel at: %s", kernel_url)
-            response = await gateway_request(kernel_url, method="POST", body=json_encode({}))
+            response = await gateway_request(
+                kernel_url,
+                method="POST",
+                headers={"Content-Type": "application/json"},
+                body=json_encode({}),
+            )
             self.log.debug("Restart kernel response: %d %s", response.code, response.reason)
 
     async def interrupt_kernel(self):
@@ -476,7 +486,12 @@ class GatewayKernelManager(AsyncKernelManager):
             assert self.kernel_url is not None
             kernel_url = self.kernel_url + "/interrupt"
             self.log.debug("Request interrupt kernel at: %s", kernel_url)
-            response = await gateway_request(kernel_url, method="POST", body=json_encode({}))
+            response = await gateway_request(
+                kernel_url,
+                method="POST",
+                headers={"Content-Type": "application/json"},
+                body=json_encode({}),
+            )
             self.log.debug("Interrupt kernel response: %d %s", response.code, response.reason)
 
     async def is_alive(self):

--- a/jupyter_server/i18n/__init__.py
+++ b/jupyter_server/i18n/__init__.py
@@ -15,7 +15,7 @@ I18N_DIR = dirname(__file__)
 #     ...
 #   }
 # }}
-TRANSLATIONS_CACHE = {"nbjs": {}}
+TRANSLATIONS_CACHE: dict = {"nbjs": {}}
 
 
 _accept_lang_re = re.compile(
@@ -87,7 +87,7 @@ def combine_translations(accept_language, domain="nbjs"):
     Returns data re-packaged in jed1.x format.
     """
     lang_codes = parse_accept_lang_header(accept_language)
-    combined = {}
+    combined: dict = {}
     for language in lang_codes:
         if language == "en":
             # en is default, all translations are in frontend.

--- a/jupyter_server/log.py
+++ b/jupyter_server/log.py
@@ -5,10 +5,37 @@
 #  the file COPYING, distributed as part of this software.
 # -----------------------------------------------------------------------------
 import json
+from urllib.parse import urlparse, urlunparse
 
 from tornado.log import access_log
 
 from .prometheus.log_functions import prometheus_log_method
+
+# url params to be scrubbed if seen
+# any url param that *contains* one of these
+# will be scrubbed from logs
+_SCRUB_PARAM_KEYS = {"token", "auth", "key", "code", "state", "xsrf"}
+
+
+def _scrub_uri(uri: str) -> str:
+    """scrub auth info from uri"""
+    parsed = urlparse(uri)
+    if parsed.query:
+        # check for potentially sensitive url params
+        # use manual list + split rather than parsing
+        # to minimally perturb original
+        parts = parsed.query.split("&")
+        changed = False
+        for i, s in enumerate(parts):
+            key, sep, value = s.partition("=")
+            for substring in _SCRUB_PARAM_KEYS:
+                if substring in key:
+                    parts[i] = f"{key}{sep}[secret]"
+                    changed = True
+        if changed:
+            parsed = parsed._replace(query="&".join(parts))
+            return urlunparse(parsed)
+    return uri
 
 
 def log_request(handler):
@@ -41,13 +68,13 @@ def log_request(handler):
         status=status,
         method=request.method,
         ip=request.remote_ip,
-        uri=request.uri,
+        uri=_scrub_uri(request.uri),
         request_time=request_time,
     )
     msg = "{status} {method} {uri} ({ip}) {request_time:.2f}ms"
     if status >= 400:
         # log bad referers
-        ns["referer"] = request.headers.get("Referer", "None")
+        ns["referer"] = _scrub_uri(request.headers.get("Referer", "None"))
         msg = msg + " referer={referer}"
     if status >= 500 and status != 502:
         # Log a subset of the headers if it caused an error.

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -34,7 +34,9 @@ pytest_plugins = [
 import asyncio
 
 if os.name == "nt" and sys.version_info >= (3, 7):
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    asyncio.set_event_loop_policy(
+        asyncio.WindowsSelectorEventLoopPolicy()  # type:ignore[attr-defined]
+    )
 
 
 # ============ Move to Jupyter Core =============

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -299,10 +299,7 @@ def jp_ensure_app_fixture(request):
 @pytest.fixture(scope="function")
 def jp_serverapp(jp_ensure_app_fixture, jp_server_config, jp_argv, jp_configurable_serverapp):
     """Starts a Jupyter Server instance based on the established configuration values."""
-    app = jp_configurable_serverapp(config=jp_server_config, argv=jp_argv)
-    yield app
-    app.remove_server_info_file()
-    app.remove_browser_open_files()
+    return jp_configurable_serverapp(config=jp_server_config, argv=jp_argv)
 
 
 @pytest.fixture
@@ -463,48 +460,19 @@ def jp_create_notebook(jp_root_dir):
 
 
 @pytest.fixture(autouse=True)
-def jp_server_cleanup():
+def jp_server_cleanup(io_loop):
     yield
+    app: ServerApp = ServerApp.instance()
+    loop = io_loop.asyncio_loop
+    loop.run_until_complete(app._cleanup())
     ServerApp.clear_instance()
 
 
 @pytest.fixture
 def jp_cleanup_subprocesses(jp_serverapp):
-    """Clean up subprocesses started by a Jupyter Server, i.e. kernels and terminal."""
+    """DEPRECATED: The jp_server_cleanup fixture automatically cleans up the singleton ServerApp class"""
 
     async def _():
-        terminal_cleanup = jp_serverapp.web_app.settings["terminal_manager"].terminate_all
-        kernel_cleanup = jp_serverapp.kernel_manager.shutdown_all
-
-        async def kernel_cleanup_steps():
-            # Try a graceful shutdown with a timeout
-            try:
-                await asyncio.wait_for(kernel_cleanup(), timeout=15.0)
-            except asyncio.TimeoutError:
-                # Now force a shutdown
-                try:
-                    await asyncio.wait_for(kernel_cleanup(now=True), timeout=15.0)
-                except asyncio.TimeoutError:
-                    print(Exception("Kernel never shutdown!"))
-            except Exception as e:
-                print(e)
-
-        if asyncio.iscoroutinefunction(terminal_cleanup):
-            try:
-                await terminal_cleanup()
-            except Exception as e:
-                print(e)
-        else:
-            try:
-                await terminal_cleanup()
-            except Exception as e:
-                print(e)
-        if asyncio.iscoroutinefunction(kernel_cleanup):
-            await kernel_cleanup_steps()
-        else:
-            try:
-                kernel_cleanup()
-            except Exception as e:
-                print(e)
+        pass
 
     return _

--- a/jupyter_server/pytest_plugin.py
+++ b/jupyter_server/pytest_plugin.py
@@ -238,13 +238,18 @@ def jp_configurable_serverapp(
         c = Config(config)
         c.NotebookNotary.db_file = ":memory:"
         token = hexlify(os.urandom(4)).decode("ascii")
+
+        # Allow tests to configure root_dir via a file, argv, or its
+        # default (cwd) by specifying a value of None.
+        if root_dir is not None:
+            kwargs["root_dir"] = str(root_dir)
+
         app = ServerApp.instance(
             # Set the log level to debug for testing purposes
             log_level="DEBUG",
             port=http_port,
             port_retries=0,
             open_browser=False,
-            root_dir=str(root_dir),
             base_url=base_url,
             config=c,
             allow_root=True,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -25,7 +25,6 @@ import threading
 import time
 import urllib
 import warnings
-import webbrowser
 from base64 import encodebytes
 
 try:
@@ -2689,6 +2688,10 @@ class ServerApp(JupyterApp):
         return assembled_url, open_file
 
     def launch_browser(self):
+        # Deferred import for environments that do not have
+        # the webbrowser module.
+        import webbrowser
+
         try:
             browser = webbrowser.get(self.browser or None)
         except webbrowser.Error as e:

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1618,7 +1618,10 @@ class ServerApp(JupyterApp):
         # preferred_dir must be equal or a subdir of root_dir
         if not value.startswith(self.root_dir):
             raise TraitError(
-                trans.gettext("preferred_dir must be equal or a subdir of root_dir: '%r'") % value
+                trans.gettext(
+                    "preferred_dir must be equal or a subdir of root_dir. preferred_dir: '%r' root_dir: '%r'"
+                )
+                % (value, self.root_dir)
             )
 
         return value

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -2427,6 +2427,8 @@ class ServerApp(JupyterApp):
         The kernels will shutdown themselves when this process no longer exists,
         but explicit shutdown allows the KernelManagers to cleanup the connection files.
         """
+        if not getattr(self, "kernel_manager", None):
+            return
         n_kernels = len(self.kernel_manager.list_kernel_ids())
         kernel_msg = trans.ngettext(
             "Shutting down %d kernel", "Shutting down %d kernels", n_kernels
@@ -2453,6 +2455,8 @@ class ServerApp(JupyterApp):
 
     async def cleanup_extensions(self):
         """Call shutdown hooks in all extensions."""
+        if not getattr(self, "extension_manager", None):
+            return
         n_extensions = len(self.extension_manager.extension_apps)
         extension_msg = trans.ngettext(
             "Shutting down %d extension", "Shutting down %d extensions", n_extensions
@@ -2732,6 +2736,8 @@ class ServerApp(JupyterApp):
         await self.cleanup_extensions()
         await self.cleanup_kernels()
         await self.cleanup_terminals()
+        if getattr(self, "session_manager", None):
+            self.session_manager.close()
 
     def start_ioloop(self):
         """Start the IO Loop."""
@@ -2760,7 +2766,8 @@ class ServerApp(JupyterApp):
     async def _stop(self):
         """Cleanup resources and stop the IO Loop."""
         await self._cleanup()
-        self.io_loop.stop()
+        if getattr(self, "io_loop", None):
+            self.io_loop.stop()
 
     def stop(self, from_signal=False):
         """Cleanup resources and stop the server."""

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -32,7 +32,7 @@ try:
     import resource
 except ImportError:
     # Windows
-    resource = None
+    resource = None  # type:ignore[assignment]
 
 from jinja2 import Environment, FileSystemLoader
 from jupyter_core.paths import secure_write
@@ -275,7 +275,7 @@ class ServerWebApplication(web.Application):
             _template_path = (_template_path,)
         template_path = [os.path.expanduser(path) for path in _template_path]
 
-        jenv_opt = {"autoescape": True}
+        jenv_opt: dict = {"autoescape": True}
         jenv_opt.update(jinja_env_options if jinja_env_options else {})
 
         env = Environment(
@@ -1036,7 +1036,7 @@ class ServerApp(JupyterApp):
             return os.getenv("JUPYTER_TOKEN")
         if os.getenv("JUPYTER_TOKEN_FILE"):
             self._token_generated = False
-            with open(os.getenv("JUPYTER_TOKEN_FILE")) as token_file:
+            with open(os.getenv("JUPYTER_TOKEN_FILE", "")) as token_file:
                 return token_file.read()
         if self.password:
             # no token if password is enabled
@@ -1191,10 +1191,10 @@ class ServerApp(JupyterApp):
         except ValueError:
             # Address is a hostname
             for info in socket.getaddrinfo(self.ip, self.port, 0, socket.SOCK_STREAM):
-                addr = info[4][0]
+                addr = info[4][0]  # type:ignore[assignment]
 
                 try:
-                    parsed = ipaddress.ip_address(addr.split("%")[0])
+                    parsed = ipaddress.ip_address(addr.split("%")[0])  # type:ignore[union-attr]
                 except ValueError:
                     self.log.warning("Unrecognised IP address: %r", addr)
                     continue
@@ -1202,7 +1202,10 @@ class ServerApp(JupyterApp):
                 # Macs map localhost to 'fe80::1%lo0', a link local address
                 # scoped to the loopback interface. For now, we'll assume that
                 # any scoped link-local address is effectively local.
-                if not (parsed.is_loopback or (("%" in addr) and parsed.is_link_local)):
+                if not (
+                    parsed.is_loopback
+                    or (("%" in addr) and parsed.is_link_local)  # type:ignore[operator]
+                ):
                     return True
             return False
         else:
@@ -2015,12 +2018,7 @@ class ServerApp(JupyterApp):
                 query = urllib.parse.urlencode({"token": token})
         # Build the URL Parts to dump.
         urlparts = urllib.parse.ParseResult(
-            scheme=scheme,
-            netloc=netloc,
-            path=path,
-            params=None,
-            query=query,
-            fragment=None,
+            scheme=scheme, netloc=netloc, path=path, query=query or "", params="", fragment=""
         )
         return urlparts
 
@@ -2678,6 +2676,7 @@ class ServerApp(JupyterApp):
         assembled_url, _ = self._prepare_browser_open()
 
         def target():
+            assert browser is not None
             browser.open(assembled_url, new=self.webbrowser_open_new)
 
         threading.Thread(target=target).start()

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -501,10 +501,29 @@ def shutdown_server(server_info, timeout=5, log=None):
     url = server_info["url"]
     pid = server_info["pid"]
 
-    if log:
-        log.debug("POST request to %sapi/shutdown", url)
+    try:
+        shutdown_url = urljoin(url, "api/shutdown")
+        if log:
+            log.debug("POST request to %s", shutdown_url)
+        fetch(
+            shutdown_url,
+            method="POST",
+            body=b"",
+            headers={"Authorization": "token " + server_info["token"]},
+        )
+    except Exception as ex:
+        if not str(ex) == "Unknown URL scheme.":
+            raise ex
+        if log:
+            log.debug("Was not a HTTP scheme. Treating as socket instead.")
+            log.debug("POST request to %s", url)
+        fetch(
+            url,
+            method="POST",
+            body=b"",
+            headers={"Authorization": "token " + server_info["token"]},
+        )
 
-    fetch(url, method="POST", body=b"", headers={"Authorization": "token " + server_info["token"]})
     # Poll to see if it shut down.
     for _ in range(timeout * 10):
         if not check_pid(pid):

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1451,17 +1451,27 @@ class ServerApp(JupyterApp):
             )
 
     kernel_manager_class = Type(
-        default_value=AsyncMappingKernelManager,
         klass=MappingKernelManager,
         config=True,
         help=_i18n("The kernel manager class to use."),
     )
 
+    @default("kernel_manager_class")
+    def _default_kernel_manager_class(self):
+        if self.gateway_config.gateway_enabled:
+            return "jupyter_server.gateway.managers.GatewayMappingKernelManager"
+        return AsyncMappingKernelManager
+
     session_manager_class = Type(
-        default_value=SessionManager,
         config=True,
         help=_i18n("The session manager class to use."),
     )
+
+    @default("session_manager_class")
+    def _default_session_manager_class(self):
+        if self.gateway_config.gateway_enabled:
+            return "jupyter_server.gateway.managers.GatewaySessionManager"
+        return SessionManager
 
     config_manager_class = Type(
         default_value=ConfigManager,
@@ -1472,7 +1482,6 @@ class ServerApp(JupyterApp):
     kernel_spec_manager = Instance(KernelSpecManager, allow_none=True)
 
     kernel_spec_manager_class = Type(
-        default_value=KernelSpecManager,
         config=True,
         help="""
         The kernel spec manager class to use. Should be a subclass
@@ -1482,6 +1491,12 @@ class ServerApp(JupyterApp):
         without warning between this version of Jupyter and the next stable one.
         """,
     )
+
+    @default("kernel_spec_manager_class")
+    def _default_kernel_spec_manager_class(self):
+        if self.gateway_config.gateway_enabled:
+            return "jupyter_server.gateway.managers.GatewayKernelSpecManager"
+        return KernelSpecManager
 
     login_handler_class = Type(
         default_value=LoginHandler,
@@ -1821,15 +1836,6 @@ class ServerApp(JupyterApp):
         # If gateway server is configured, replace appropriate managers to perform redirection.  To make
         # this determination, instantiate the GatewayClient config singleton.
         self.gateway_config = GatewayClient.instance(parent=self)
-
-        if self.gateway_config.gateway_enabled:
-            self.kernel_manager_class = (
-                "jupyter_server.gateway.managers.GatewayMappingKernelManager"
-            )
-            self.session_manager_class = "jupyter_server.gateway.managers.GatewaySessionManager"
-            self.kernel_spec_manager_class = (
-                "jupyter_server.gateway.managers.GatewayKernelSpecManager"
-            )
 
         self.kernel_spec_manager = self.kernel_spec_manager_class(
             parent=self,

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -504,7 +504,7 @@ def shutdown_server(server_info, timeout=5, log=None):
     if log:
         log.debug("POST request to %sapi/shutdown", url)
 
-    fetch(url, method="POST", headers={"Authorization": "token " + server_info["token"]})
+    fetch(url, method="POST", body=b"", headers={"Authorization": "token " + server_info["token"]})
     # Poll to see if it shut down.
     for _ in range(timeout * 10):
         if not check_pid(pid):

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1593,11 +1593,22 @@ class ServerApp(JupyterApp):
             value = os.path.abspath(value)
         return value
 
+    # Because the validation of preferred_dir depends on root_dir and validation
+    # occurs when the trait is loaded, there are times when we should defer the
+    # validation of preferred_dir (e.g., when preferred_dir is defined via CLI
+    # and root_dir is defined via a config file).
+    _defer_preferred_dir_validation = False
+
     @validate("root_dir")
     def _root_dir_validate(self, proposal):
         value = self._normalize_dir(proposal["value"])
         if not os.path.isdir(value):
             raise TraitError(trans.gettext("No such directory: '%r'") % value)
+
+        if self._defer_preferred_dir_validation:
+            # If we're here, then preferred_dir is configured on the CLI and
+            # root_dir is configured in a file
+            self._preferred_dir_validation(self.preferred_dir, value)
         return value
 
     preferred_dir = Unicode(
@@ -1615,16 +1626,28 @@ class ServerApp(JupyterApp):
         if not os.path.isdir(value):
             raise TraitError(trans.gettext("No such preferred dir: '%r'") % value)
 
-        # preferred_dir must be equal or a subdir of root_dir
-        if not value.startswith(self.root_dir):
+        # Before we validate against root_dir, check if this trait is defined on the CLI
+        # and root_dir is not.  If that's the case, we'll defer it's further validation
+        # until root_dir is validated or the server is starting (the latter occurs when
+        # the default root_dir (cwd) is used).
+        cli_config = self.cli_config.get("ServerApp", {})
+        if "preferred_dir" in cli_config and "root_dir" not in cli_config:
+            self._defer_preferred_dir_validation = True
+
+        if not self._defer_preferred_dir_validation:  # Validate now
+            self._preferred_dir_validation(value, self.root_dir)
+        return value
+
+    def _preferred_dir_validation(self, preferred_dir: str, root_dir: str) -> None:
+        """Validate preferred dir relative to root_dir - preferred_dir must be equal or a subdir of root_dir"""
+        if not preferred_dir.startswith(root_dir):
             raise TraitError(
                 trans.gettext(
                     "preferred_dir must be equal or a subdir of root_dir. preferred_dir: '%r' root_dir: '%r'"
                 )
-                % (value, self.root_dir)
+                % (preferred_dir, root_dir)
             )
-
-        return value
+        self._defer_preferred_dir_validation = False
 
     @observe("root_dir")
     def _root_dir_changed(self, change):
@@ -2387,6 +2410,10 @@ class ServerApp(JupyterApp):
         # Parse command line, load ServerApp config files,
         # and update ServerApp config.
         super().initialize(argv=argv)
+        if self._defer_preferred_dir_validation:
+            # If we're here, then preferred_dir is configured on the CLI and
+            # root_dir has the default value (cwd)
+            self._preferred_dir_validation(self.preferred_dir, self.root_dir)
         if self._dispatching:
             return
         # Then, use extensions' config loading mechanism to

--- a/jupyter_server/serverapp.py
+++ b/jupyter_server/serverapp.py
@@ -1629,22 +1629,11 @@ class ServerApp(JupyterApp):
             value = os.path.abspath(value)
         return value
 
-    # Because the validation of preferred_dir depends on root_dir and validation
-    # occurs when the trait is loaded, there are times when we should defer the
-    # validation of preferred_dir (e.g., when preferred_dir is defined via CLI
-    # and root_dir is defined via a config file).
-    _defer_preferred_dir_validation = False
-
     @validate("root_dir")
     def _root_dir_validate(self, proposal):
         value = self._normalize_dir(proposal["value"])
         if not os.path.isdir(value):
             raise TraitError(trans.gettext("No such directory: '%r'") % value)
-
-        if self._defer_preferred_dir_validation:
-            # If we're here, then preferred_dir is configured on the CLI and
-            # root_dir is configured in a file
-            self._preferred_dir_validation(self.preferred_dir, value)
         return value
 
     preferred_dir = Unicode(
@@ -1661,38 +1650,7 @@ class ServerApp(JupyterApp):
         value = self._normalize_dir(proposal["value"])
         if not os.path.isdir(value):
             raise TraitError(trans.gettext("No such preferred dir: '%r'") % value)
-
-        # Before we validate against root_dir, check if this trait is defined on the CLI
-        # and root_dir is not.  If that's the case, we'll defer it's further validation
-        # until root_dir is validated or the server is starting (the latter occurs when
-        # the default root_dir (cwd) is used).
-        cli_config = self.cli_config.get("ServerApp", {})
-        if "preferred_dir" in cli_config and "root_dir" not in cli_config:
-            self._defer_preferred_dir_validation = True
-
-        if not self._defer_preferred_dir_validation:  # Validate now
-            self._preferred_dir_validation(value, self.root_dir)
         return value
-
-    def _preferred_dir_validation(self, preferred_dir: str, root_dir: str) -> None:
-        """Validate preferred dir relative to root_dir - preferred_dir must be equal or a subdir of root_dir"""
-        if not preferred_dir.startswith(root_dir):
-            raise TraitError(
-                trans.gettext(
-                    "preferred_dir must be equal or a subdir of root_dir. preferred_dir: '%r' root_dir: '%r'"
-                )
-                % (preferred_dir, root_dir)
-            )
-        self._defer_preferred_dir_validation = False
-
-    @observe("root_dir")
-    def _root_dir_changed(self, change):
-        self._root_dir_set = True
-        if not self.preferred_dir.startswith(change["new"]):
-            self.log.warning(
-                trans.gettext("Value of preferred_dir updated to use value of root_dir")
-            )
-            self.preferred_dir = change["new"]
 
     @observe("server_extensions")
     def _update_server_extensions(self, change):
@@ -1868,6 +1826,9 @@ class ServerApp(JupyterApp):
             parent=self,
             log=self.log,
         )
+        # Trigger a default/validation here explicitly while we still support the
+        # deprecated trait on ServerApp (FIXME remove when deprecation finalized)
+        self.contents_manager.preferred_dir
         self.session_manager = self.session_manager_class(
             parent=self,
             log=self.log,
@@ -2432,10 +2393,6 @@ class ServerApp(JupyterApp):
         # Parse command line, load ServerApp config files,
         # and update ServerApp config.
         super().initialize(argv=argv)
-        if self._defer_preferred_dir_validation:
-            # If we're here, then preferred_dir is configured on the CLI and
-            # root_dir has the default value (cwd)
-            self._preferred_dir_validation(self.preferred_dir, self.root_dir)
         if self._dispatching:
             return
         # Then, use extensions' config loading mechanism to

--- a/jupyter_server/services/config/manager.py
+++ b/jupyter_server/services/config/manager.py
@@ -22,7 +22,7 @@ class ConfigManager(LoggingConfigurable):
 
     def get(self, section_name):
         """Get the config from all config sections."""
-        config = {}
+        config: dict = {}
         # step through back to front, to ensure front of the list is top priority
         for p in self.read_config_path[::-1]:
             cm = BaseJSONConfigManager(config_dir=p)

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -204,11 +204,12 @@ class FileManagerMixin(Configurable):
         Depending on flag 'use_atomic_writing', the wrapper perform an actual atomic writing or
         simply writes the file (whatever an old exists or not)"""
         with self.perm_to_403(os_path):
+            kwargs["log"] = self.log
             if self.use_atomic_writing:
-                with atomic_writing(os_path, *args, log=self.log, **kwargs) as f:
+                with atomic_writing(os_path, *args, **kwargs) as f:
                     yield f
             else:
-                with _simple_writing(os_path, *args, log=self.log, **kwargs) as f:
+                with _simple_writing(os_path, *args, **kwargs) as f:
                     yield f
 
     @contextmanager

--- a/jupyter_server/services/contents/fileio.py
+++ b/jupyter_server/services/contents/fileio.py
@@ -254,6 +254,9 @@ class FileManagerMixin(Configurable):
         404: if path is outside root
         """
         root = os.path.abspath(self.root_dir)
+        # to_os_path is not safe if path starts with a drive, since os.path.join discards first part
+        if os.path.splitdrive(path)[0]:
+            raise HTTPError(404, "%s is not a relative API path" % path)
         os_path = to_os_path(path, root)
         if not (os.path.abspath(os_path) + os.path.sep).startswith(root):
             raise HTTPError(404, "%s is outside root contents directory" % path)

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -331,7 +331,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         os_path = self._get_os_path(path)
 
         if content:
-            validation_error = {}
+            validation_error: dict = {}
             nb = self._read_notebook(
                 os_path, as_version=4, capture_validation_error=validation_error
             )
@@ -412,7 +412,7 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         os_path = self._get_os_path(path)
         self.log.debug("Saving %s", os_path)
 
-        validation_error = {}
+        validation_error: dict = {}
         try:
             if model["type"] == "notebook":
                 nb = nbformat.from_dict(model["content"])
@@ -657,7 +657,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         os_path = self._get_os_path(path)
 
         if content:
-            validation_error = {}
+            validation_error: dict = {}
             nb = await self._read_notebook(
                 os_path, as_version=4, capture_validation_error=validation_error
             )
@@ -738,7 +738,7 @@ class AsyncFileContentsManager(FileContentsManager, AsyncFileManagerMixin, Async
         os_path = self._get_os_path(path)
         self.log.debug("Saving %s", os_path)
 
-        validation_error = {}
+        validation_error: dict = {}
         try:
             if model["type"] == "notebook":
                 nb = nbformat.from_dict(model["content"])

--- a/jupyter_server/services/contents/filemanager.py
+++ b/jupyter_server/services/contents/filemanager.py
@@ -7,7 +7,9 @@ import os
 import shutil
 import stat
 import sys
+import warnings
 from datetime import datetime
+from pathlib import Path
 
 import nbformat
 from anyio.to_thread import run_sync
@@ -19,6 +21,7 @@ from traitlets import Bool, TraitError, Unicode, default, validate
 from jupyter_server import _tz as tz
 from jupyter_server.base.handlers import AuthenticatedFileHandler
 from jupyter_server.transutils import _i18n
+from jupyter_server.utils import to_api_path
 
 from .filecheckpoints import AsyncFileCheckpoints, FileCheckpoints
 from .fileio import AsyncFileManagerMixin, FileManagerMixin
@@ -54,6 +57,34 @@ class FileContentsManager(FileManagerMixin, ContentsManager):
         if not os.path.isdir(value):
             raise TraitError("%r is not a directory" % value)
         return value
+
+    @default("preferred_dir")
+    def _default_preferred_dir(self):
+        try:
+            value = self.parent.preferred_dir
+            if value == self.parent.root_dir:
+                value = None
+        except AttributeError:
+            pass
+        else:
+            if value is not None:
+                warnings.warn(
+                    "ServerApp.preferred_dir config is deprecated in jupyter-server 2.0. Use FileContentsManager.preferred_dir instead",
+                    FutureWarning,
+                    stacklevel=3,
+                )
+                try:
+                    path = Path(value)
+                    return path.relative_to(self.root_dir).as_posix()
+                except ValueError:
+                    raise TraitError("%s is outside root contents directory" % value) from None
+        return ""
+
+    @validate("preferred_dir")
+    def _validate_preferred_dir(self, proposal):
+        # It should be safe to pass an API path through this method:
+        proposal["value"] = to_api_path(proposal["value"], self.root_dir)
+        return super()._validate_preferred_dir(proposal)
 
     @default("checkpoints_class")
     def _checkpoints_class_default(self):

--- a/jupyter_server/services/contents/handlers.py
+++ b/jupyter_server/services/contents/handlers.py
@@ -54,7 +54,7 @@ def validate_model(model, expect_content):
                 f"Keys unexpectedly None: {errors}",
             )
     else:
-        errors = {key: model[key] for key in maybe_none_keys if model[key] is not None}
+        errors = {key: model[key] for key in maybe_none_keys if model[key] is not None}  # type: ignore[assignment]
         if errors:
             raise web.HTTPError(
                 500,
@@ -102,10 +102,10 @@ class ContentsHandler(ContentsAPIHandler):
         format = self.get_query_argument("format", default=None)
         if format not in {None, "text", "base64"}:
             raise web.HTTPError(400, "Format %r is invalid" % format)
-        content = self.get_query_argument("content", default="1")
-        if content not in {"0", "1"}:
-            raise web.HTTPError(400, "Content %r is invalid" % content)
-        content = int(content)
+        content_str = self.get_query_argument("content", default="1")
+        if content_str not in {"0", "1"}:
+            raise web.HTTPError(400, "Content %r is invalid" % content_str)
+        content = int(content_str or "")
 
         model = await ensure_async(
             self.contents_manager.get(

--- a/jupyter_server/services/kernels/handlers.py
+++ b/jupyter_server/services/kernels/handlers.py
@@ -397,8 +397,11 @@ class ZMQChannelsHandler(AuthenticatedZMQStreamHandler):
         kernel = self.kernel_manager.get_kernel(self.kernel_id)
 
         if hasattr(kernel, "ready"):
+            ready = kernel.ready
+            if not isinstance(ready, asyncio.Future):
+                ready = asyncio.wrap_future(ready)
             try:
-                await kernel.ready
+                await ready
             except Exception as e:
                 kernel.execution_state = "dead"
                 kernel.reason = str(e)

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -180,7 +180,7 @@ class MappingKernelManager(MultiKernelManager):
         self.log.warning("Kernel %s died, removing from map.", kernel_id)
         self.remove_kernel(kernel_id)
 
-    def cwd_for_path(self, path):
+    def cwd_for_path(self, path, **kwargs):
         """Turn API path into absolute OS path."""
         os_path = to_os_path(path, self.root_dir)
         # in the case of documents and kernels not being on the same filesystem,
@@ -212,7 +212,7 @@ class MappingKernelManager(MultiKernelManager):
         """
         if kernel_id is None or kernel_id not in self:
             if path is not None:
-                kwargs["cwd"] = self.cwd_for_path(path)
+                kwargs["cwd"] = self.cwd_for_path(path, env=kwargs.get("env", {}))
             if kernel_id is not None:
                 kwargs["kernel_id"] = kernel_id
             kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, **kwargs))

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -149,6 +149,7 @@ class MappingKernelManager(MultiKernelManager):
 
     def __init__(self, **kwargs):
         self.pinned_superclass = MultiKernelManager
+        self._pending_kernel_tasks = {}
         self.pinned_superclass.__init__(self, **kwargs)
         self.last_kernel_activity = utcnow()
 
@@ -216,9 +217,11 @@ class MappingKernelManager(MultiKernelManager):
                 kwargs["kernel_id"] = kernel_id
             kernel_id = await ensure_async(self.pinned_superclass.start_kernel(self, **kwargs))
             self._kernel_connections[kernel_id] = 0
-            fut = asyncio.ensure_future(self._finish_kernel_start(kernel_id))
+            task = asyncio.create_task(self._finish_kernel_start(kernel_id))
             if not getattr(self, "use_pending_kernels", None):
-                await fut
+                await task
+            else:
+                self._pending_kernel_tasks[kernel_id] = task
             # add busy/activity markers:
             kernel = self.get_kernel(kernel_id)
             kernel.execution_state = "starting"
@@ -245,8 +248,8 @@ class MappingKernelManager(MultiKernelManager):
         if hasattr(km, "ready"):
             try:
                 await km.ready
-            except Exception:
-                self.log.exception(km.ready.exception())
+            except Exception as e:
+                self.log.exception(e)
                 return
 
         self._kernel_ports[kernel_id] = km.ports
@@ -372,7 +375,7 @@ class MappingKernelManager(MultiKernelManager):
         buffer_info = self._kernel_buffers.pop(kernel_id)
         # close buffering streams
         for stream in buffer_info["channels"].values():
-            if not stream.closed():
+            if not stream.socket.closed:
                 stream.on_recv(None)
                 stream.close()
 
@@ -387,12 +390,17 @@ class MappingKernelManager(MultiKernelManager):
     def shutdown_kernel(self, kernel_id, now=False, restart=False):
         """Shutdown a kernel by kernel_id"""
         self._check_kernel_id(kernel_id)
-        self.stop_watching_activity(kernel_id)
-        self.stop_buffering(kernel_id)
 
         # Decrease the metric of number of kernels
         # running for the relevant kernel type by 1
         KERNEL_CURRENTLY_RUNNING_TOTAL.labels(type=self._kernels[kernel_id].kernel_name).dec()
+
+        if kernel_id in self._pending_kernel_tasks:
+            task = self._pending_kernel_tasks.pop(kernel_id)
+            task.cancel()
+        else:
+            self.stop_watching_activity(kernel_id)
+            self.stop_buffering(kernel_id)
 
         self.pinned_superclass.shutdown_kernel(self, kernel_id, now=now, restart=restart)
 
@@ -533,7 +541,8 @@ class MappingKernelManager(MultiKernelManager):
         """Stop watching IOPub messages on a kernel for activity."""
         kernel = self._kernels[kernel_id]
         if getattr(kernel, "_activity_stream", None):
-            kernel._activity_stream.close()
+            if not kernel._activity_stream.socket.closed:
+                kernel._activity_stream.close()
             kernel._activity_stream = None
 
     def initialize_culler(self):
@@ -638,19 +647,24 @@ class AsyncMappingKernelManager(MappingKernelManager, AsyncMultiKernelManager):
         self.pinned_superclass = AsyncMultiKernelManager
         self.pinned_superclass.__init__(self, **kwargs)
         self.last_kernel_activity = utcnow()
+        self._pending_kernel_tasks = {}
 
     async def shutdown_kernel(self, kernel_id, now=False, restart=False):
         """Shutdown a kernel by kernel_id"""
         self._check_kernel_id(kernel_id)
-        self.stop_watching_activity(kernel_id)
-        self.stop_buffering(kernel_id)
 
         # Decrease the metric of number of kernels
         # running for the relevant kernel type by 1
         KERNEL_CURRENTLY_RUNNING_TOTAL.labels(type=self._kernels[kernel_id].kernel_name).dec()
 
+        if kernel_id in self._pending_kernel_tasks:
+            task = self._pending_kernel_tasks.pop(kernel_id)
+            task.cancel()
+        else:
+            self.stop_watching_activity(kernel_id)
+            self.stop_buffering(kernel_id)
+
         # Finish shutting down the kernel before clearing state to avoid a race condition.
-        ret = await self.pinned_superclass.shutdown_kernel(
+        return await self.pinned_superclass.shutdown_kernel(
             self, kernel_id, now=now, restart=restart
         )
-        return ret

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -246,8 +246,11 @@ class MappingKernelManager(MultiKernelManager):
     async def _finish_kernel_start(self, kernel_id):
         km = self.get_kernel(kernel_id)
         if hasattr(km, "ready"):
+            ready = km.ready
+            if not isinstance(ready, asyncio.Future):
+                ready = asyncio.wrap_future(ready)
             try:
-                await km.ready
+                await ready
             except Exception:
                 self.log.exception("Error waiting for kernel manager ready")
                 return

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -411,7 +411,7 @@ class MappingKernelManager(MultiKernelManager):
         kernel = self.get_kernel(kernel_id)
         # return a Future that will resolve when the kernel has successfully restarted
         channel = kernel.connect_shell()
-        future = Future()
+        future: Future = Future()
 
         def finish():
             """Common cleanup when restart finishes/fails for any reason."""

--- a/jupyter_server/services/kernels/kernelmanager.py
+++ b/jupyter_server/services/kernels/kernelmanager.py
@@ -227,15 +227,15 @@ class MappingKernelManager(MultiKernelManager):
             kernel.execution_state = "starting"
             kernel.reason = ""
             kernel.last_activity = utcnow()
-            self.log.info("Kernel started: %s" % kernel_id)
-            self.log.debug("Kernel args: %r" % kwargs)
+            self.log.info("Kernel started: %s", kernel_id)
+            self.log.debug("Kernel args: %r", kwargs)
 
             # Increase the metric of number of kernels running
             # for the relevant kernel type by 1
             KERNEL_CURRENTLY_RUNNING_TOTAL.labels(type=self._kernels[kernel_id].kernel_name).inc()
 
         else:
-            self.log.info("Using existing kernel: %s" % kernel_id)
+            self.log.info("Using existing kernel: %s", kernel_id)
 
         # Initialize culling if not already
         if not self._initialized_culler:
@@ -248,8 +248,8 @@ class MappingKernelManager(MultiKernelManager):
         if hasattr(km, "ready"):
             try:
                 await km.ready
-            except Exception as e:
-                self.log.exception(e)
+            except Exception:
+                self.log.exception("Error waiting for kernel manager ready")
                 return
 
         self._kernel_ports[kernel_id] = km.ports
@@ -276,7 +276,7 @@ class MappingKernelManager(MultiKernelManager):
         changed_ports = self._get_changed_ports(kernel_id)
         if changed_ports:
             # If changed, update captured ports and return True, else return False.
-            self.log.debug(f"Port change detected for kernel: {kernel_id}")
+            self.log.debug("Port change detected for kernel: %s", kernel_id)
             self._kernel_ports[kernel_id] = changed_ports
             return True
         return False

--- a/jupyter_server/services/nbconvert/handlers.py
+++ b/jupyter_server/services/nbconvert/handlers.py
@@ -11,11 +11,16 @@ from ...base.handlers import APIHandler
 AUTH_RESOURCE = "nbconvert"
 
 
-LOCK = asyncio.Lock()
-
-
 class NbconvertRootHandler(APIHandler):
     auth_resource = AUTH_RESOURCE
+    _exporter_lock: asyncio.Lock
+
+    def initialize(self, **kwargs):
+        super().initialize(**kwargs)
+        # share lock across instances of this handler class
+        if not hasattr(self.__class__, "_exporter_lock"):
+            self.__class__._exporter_lock = asyncio.Lock()
+        self._exporter_lock = self.__class__._exporter_lock
 
     @web.authenticated
     @authorized
@@ -28,22 +33,22 @@ class NbconvertRootHandler(APIHandler):
         # Some exporters use the filesystem when instantiating, delegate that
         # to a thread so we don't block the event loop for it.
         exporters = await run_sync(base.get_export_names)
-        for exporter_name in exporters:
-            try:
-                async with LOCK:
+        async with self._exporter_lock:
+            for exporter_name in exporters:
+                try:
                     exporter_class = await run_sync(base.get_exporter, exporter_name)
-            except ValueError:
-                # I think the only way this will happen is if the entrypoint
-                # is uninstalled while this method is running
-                continue
-            # XXX: According to the docs, it looks like this should be set to None
-            # if the exporter shouldn't be exposed to the front-end and a friendly
-            # name if it should. However, none of the built-in exports have it defined.
-            # if not exporter_class.export_from_notebook:
-            #    continue
-            res[exporter_name] = {
-                "output_mimetype": exporter_class.output_mimetype,
-            }
+                except ValueError:
+                    # I think the only way this will happen is if the entrypoint
+                    # is uninstalled while this method is running
+                    continue
+                # XXX: According to the docs, it looks like this should be set to None
+                # if the exporter shouldn't be exposed to the front-end and a friendly
+                # name if it should. However, none of the built-in exports have it defined.
+                # if not exporter_class.export_from_notebook:
+                #    continue
+                res[exporter_name] = {
+                    "output_mimetype": exporter_class.output_mimetype,
+                }
 
         self.finish(json.dumps(res))
 

--- a/jupyter_server/services/sessions/handlers.py
+++ b/jupyter_server/services/sessions/handlers.py
@@ -64,6 +64,7 @@ class SessionRootHandler(SessionsAPIHandler):
 
         name = model.get("name", None)
         kernel = model.get("kernel", {})
+        session_id = model.get("session_id", None)
         kernel_name = kernel.get("name", None)
         kernel_id = kernel.get("id", None)
 
@@ -82,6 +83,7 @@ class SessionRootHandler(SessionsAPIHandler):
                     kernel_id=kernel_id,
                     name=name,
                     type=mtype,
+                    session_id=session_id,
                 )
             except NoSuchKernel:
                 msg = (

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -8,7 +8,7 @@ try:
     import sqlite3
 except ImportError:
     # fallback on pysqlite2 if Python was build without sqlite
-    from pysqlite2 import dbapi2 as sqlite3
+    from pysqlite2 import dbapi2 as sqlite3  # type:ignore[no-redef]
 
 from dataclasses import dataclass, fields
 from typing import Union
@@ -41,7 +41,7 @@ class KernelSessionRecord:
     session_id: Union[None, str] = None
     kernel_id: Union[None, str] = None
 
-    def __eq__(self, other: "KernelSessionRecord") -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, KernelSessionRecord):
             condition1 = self.kernel_id and self.kernel_id == other.kernel_id
             condition2 = all(
@@ -103,7 +103,7 @@ class KernelSessionRecordList:
     def __str__(self):
         return str(self._records)
 
-    def __contains__(self, record: Union[KernelSessionRecord, str]):
+    def __contains__(self, record: Union[KernelSessionRecord, str]) -> bool:
         """Search for records by kernel_id and session_id"""
         if isinstance(record, KernelSessionRecord) and record in self._records:
             return True

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -11,6 +11,7 @@ except ImportError:
     # fallback on pysqlite2 if Python was build without sqlite
     from pysqlite2 import dbapi2 as sqlite3  # type:ignore[no-redef]
 
+import asyncio
 from dataclasses import dataclass, fields
 from typing import Union
 
@@ -197,6 +198,9 @@ class SessionManager(LoggingConfigurable):
     _connection = None
     _columns = {"session_id", "path", "name", "type", "kernel_id"}
 
+    fut_kernel_id_dict = {}
+    polling_kernel = False
+
     @property
     def cursor(self):
         """Start a cursor and create a database called 'session'"""
@@ -248,10 +252,16 @@ class SessionManager(LoggingConfigurable):
         return str(uuid.uuid4())
 
     async def create_session(
-        self, path=None, name=None, type=None, kernel_name=None, kernel_id=None
+        self, path=None, name=None, type=None, kernel_name=None, kernel_id=None, session_id=None
     ):
         """Creates a session and returns its model"""
-        session_id = self.new_session_id()
+
+        if session_id is not None:
+            self.polling_kernel = True
+
+        if session_id is None or session_id == "":
+            session_id = self.new_session_id()
+
         record = KernelSessionRecord(session_id=session_id)
         self._pending_sessions.update(record)
         if kernel_id is not None and kernel_id in self.kernel_manager:
@@ -275,13 +285,31 @@ class SessionManager(LoggingConfigurable):
     async def start_kernel_for_session(self, session_id, path, name, type, kernel_name):
         """Start a new kernel for a given session."""
         # allow contents manager to specify kernels cwd
-        kernel_path = await ensure_async(self.contents_manager.get_kernel_path(path=path))
-        kernel_env = self.get_kernel_env(path)
-        kernel_id = await self.kernel_manager.start_kernel(
-            path=kernel_path,
-            kernel_name=kernel_name,
-            env=kernel_env,
-        )
+        if self.polling_kernel:
+            if session_id in self.fut_kernel_id_dict:
+                fut_kernel_id = self.fut_kernel_id_dict[session_id]
+                done, pending = await asyncio.wait({fut_kernel_id})
+                if fut_kernel_id in done:
+                    kernel_id = await fut_kernel_id
+                    self.fut_kernel_id_dict.pop(session_id)
+                    return kernel_id
+            else:
+                kernel_path = await ensure_async(self.contents_manager.get_kernel_path(path=path))
+                kernel_env = self.get_kernel_env(path)
+                self.fut_kernel_id_dict[session_id] = asyncio.create_task(self.kernel_manager.start_kernel(
+                    path=kernel_path,
+                    kernel_name=kernel_name,
+                    env=kernel_env,
+                ))
+            kernel_id = "waiting"
+        else:
+            kernel_path = await ensure_async(self.contents_manager.get_kernel_path(path=path))
+            kernel_env = self.get_kernel_env(path)
+            kernel_id = await self.kernel_manager.start_kernel(
+                path=kernel_path,
+                kernel_name=kernel_name,
+                env=kernel_env,
+            )
         return kernel_id
 
     async def save_session(self, session_id, path=None, name=None, type=None, kernel_id=None):
@@ -334,35 +362,47 @@ class SessionManager(LoggingConfigurable):
             returns a dictionary that includes all the information from the
             session described by the kwarg.
         """
-        if not kwargs:
-            raise TypeError("must specify a column to query")
-
-        conditions = []
-        for column in kwargs.keys():
-            if column not in self._columns:
-                raise TypeError("No such column: %r", column)
-            conditions.append("%s=?" % column)
-
-        query = "SELECT * FROM session WHERE %s" % (" AND ".join(conditions))
-
-        self.cursor.execute(query, list(kwargs.values()))
-        try:
-            row = self.cursor.fetchone()
-        except KeyError:
-            # The kernel is missing, so the session just got deleted.
-            row = None
-
-        if row is None:
-            q = []
-            for key, value in kwargs.items():
-                q.append(f"{key}={value!r}")
-
-            raise web.HTTPError(404, "Session not found: %s" % (", ".join(q)))
-
-        try:
-            model = await self.row_to_model(row)
-        except KeyError as e:
-            raise web.HTTPError(404, "Session not found: %s" % str(e))
+        session_id = kwargs["session_id"]
+        if session_id in self.fut_kernel_id_dict:
+            model = {
+                "id": "waiting",
+                "session_id": session_id,
+                "name": "Waiting for kernel to start",
+                "last_activity": None,
+                "execution_state": "starting",
+                "connections": 0,
+            }
+        else:
+            if not kwargs:
+                raise TypeError("must specify a column to query")
+    
+            conditions = []
+            for column in kwargs.keys():
+                if column not in self._columns:
+                    raise TypeError("No such column: %r", column)
+                conditions.append("%s=?" % column)
+    
+            query = "SELECT * FROM session WHERE %s" % (" AND ".join(conditions))
+    
+            self.cursor.execute(query, list(kwargs.values()))
+            try:
+                row = self.cursor.fetchone()
+            except KeyError:
+                # The kernel is missing, so the session just got deleted.
+                row = None
+    
+            if row is None:
+                q = []
+                for key, value in kwargs.items():
+                    q.append(f"{key}={value!r}")
+    
+                raise web.HTTPError(404, "Session not found: %s" % (", ".join(q)))
+    
+            try:
+                model = await self.row_to_model(row)
+            except KeyError as e:
+                raise web.HTTPError(404, "Session not found: %s" % str(e))
+        
         return model
 
     async def update_session(self, session_id, **kwargs):

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -1,6 +1,7 @@
 """A base class session manager."""
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
+import os
 import pathlib
 import uuid
 
@@ -272,7 +273,9 @@ class SessionManager(LoggingConfigurable):
         # allow contents manager to specify kernels cwd
         kernel_path = self.contents_manager.get_kernel_path(path=path)
         kernel_id = await self.kernel_manager.start_kernel(
-            path=kernel_path, kernel_name=kernel_name
+            path=kernel_path,
+            kernel_name=kernel_name,
+            env={**os.environ, "JPY_SESSION_NAME": path},
         )
         return kernel_id
 

--- a/jupyter_server/services/sessions/sessionmanager.py
+++ b/jupyter_server/services/sessions/sessionmanager.py
@@ -268,14 +268,19 @@ class SessionManager(LoggingConfigurable):
         self._pending_sessions.remove(record)
         return result
 
+    def get_kernel_env(self, path):
+        """Return the environment variables that need to be set in the kernel"""
+        return {**os.environ, "JPY_SESSION_NAME": path}
+
     async def start_kernel_for_session(self, session_id, path, name, type, kernel_name):
         """Start a new kernel for a given session."""
         # allow contents manager to specify kernels cwd
-        kernel_path = self.contents_manager.get_kernel_path(path=path)
+        kernel_path = await ensure_async(self.contents_manager.get_kernel_path(path=path))
+        kernel_env = self.get_kernel_env(path)
         kernel_id = await self.kernel_manager.start_kernel(
             path=kernel_path,
             kernel_name=kernel_name,
-            env={**os.environ, "JPY_SESSION_NAME": path},
+            env=kernel_env,
         )
         return kernel_id
 

--- a/jupyter_server/terminal/__init__.py
+++ b/jupyter_server/terminal/__init__.py
@@ -20,7 +20,7 @@ def initialize(webapp, root_dir, connection_url, settings):
     if os.name == "nt":
         default_shell = "powershell.exe"
     else:
-        default_shell = which("sh")
+        default_shell = which("sh")  # type:ignore[assignment]
     shell_override = settings.get("shell_command")
     shell = [os.environ.get("SHELL") or default_shell] if shell_override is None else shell_override
     # When the notebook server is not running in a terminal (e.g. when

--- a/jupyter_server/terminal/api_handlers.py
+++ b/jupyter_server/terminal/api_handlers.py
@@ -35,7 +35,7 @@ class TerminalRootHandler(TerminalAPIHandler):
             if not cwd.resolve().exists():
                 cwd = Path(self.settings["server_root_dir"]).expanduser() / cwd
                 if not cwd.resolve().exists():
-                    cwd = None
+                    cwd = None  # type:ignore[assignment]
 
             if cwd is None:
                 server_root_dir = self.settings["server_root_dir"]

--- a/jupyter_server/terminal/handlers.py
+++ b/jupyter_server/terminal/handlers.py
@@ -5,7 +5,6 @@ import terminado
 from tornado import web
 
 from jupyter_server._tz import utcnow
-from jupyter_server.auth.utils import warn_disabled_authorization
 
 from ..base.handlers import JupyterHandler
 from ..base.zmqhandlers import WebSocketMixin
@@ -30,10 +29,7 @@ class TermSocket(WebSocketMixin, JupyterHandler, terminado.TermSocket):
             raise web.HTTPError(403)
 
         # authorize the user.
-        if not self.authorizer:
-            # Warn if there is not authorizer.
-            warn_disabled_authorization()
-        elif not self.authorizer.is_authorized(self, user, "execute", self.auth_resource):
+        if not self.authorizer.is_authorized(self, user, "execute", self.auth_resource):
             raise web.HTTPError(403)
 
         if not args[0] in self.term_manager.terminals:

--- a/jupyter_server/traittypes.py
+++ b/jupyter_server/traittypes.py
@@ -8,6 +8,8 @@ from traitlets.utils.descriptions import describe
 class TypeFromClasses(ClassBasedTraitType):
     """A trait whose value must be a subclass of a class in a specified list of classes."""
 
+    default_value: Undefined
+
     def __init__(self, default_value=Undefined, klasses=None, **kwargs):
         """Construct a Type trait
         A Type trait specifies that its values must be subclasses of
@@ -181,6 +183,7 @@ class InstanceFromClasses(ClassBasedTraitType):
 
     def info(self):
         result = "an instance of "
+        assert self.klasses is not None
         for klass in self.klasses:
             if isinstance(klass, str):
                 result += klass
@@ -199,6 +202,7 @@ class InstanceFromClasses(ClassBasedTraitType):
     def _resolve_classes(self):
         # Resolve all string names to actual classes.
         self.importable_klasses = []
+        assert self.klasses is not None
         for klass in self.klasses:
             if isinstance(klass, str):
                 # Try importing the classes to compare. Silently, ignore if not importable.

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -111,7 +111,7 @@ def to_os_path(path, root=""):
     parts = path.strip("/").split("/")
     parts = [p for p in parts if p != ""]  # remove duplicate splits
     path = os.path.join(root, *parts)
-    return path
+    return os.path.normpath(path)
 
 
 def to_api_path(os_path, root=""):

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -149,7 +149,7 @@ def _check_pid_win32(pid):
 
     # OpenProcess returns 0 if no such process (of ours) exists
     # positive int otherwise
-    return bool(ctypes.windll.kernel32.OpenProcess(1, 0, pid))
+    return bool(ctypes.windll.kernel32.OpenProcess(1, 0, pid))  # type:ignore[attr-defined]
 
 
 def _check_pid_posix(pid):

--- a/jupyter_server/utils.py
+++ b/jupyter_server/utils.py
@@ -346,7 +346,9 @@ def fetch(urlstring, method="GET", body=None, headers=None):
     Send a HTTP, HTTPS, or HTTP+UNIX request
     to a Tornado Web Server. Returns a tornado HTTPResponse.
     """
-    with _request_for_tornado_client(urlstring) as request:
+    with _request_for_tornado_client(
+        urlstring, method=method, body=body, headers=headers
+    ) as request:
         response = HTTPClient(AsyncHTTPClient).fetch(request)
     return response
 
@@ -356,7 +358,9 @@ async def async_fetch(urlstring, method="GET", body=None, headers=None, io_loop=
     Send an asynchronous HTTP, HTTPS, or HTTP+UNIX request
     to a Tornado Web Server. Returns a tornado HTTPResponse.
     """
-    with _request_for_tornado_client(urlstring) as request:
+    with _request_for_tornado_client(
+        urlstring, method=method, body=body, headers=headers
+    ) as request:
         response = await AsyncHTTPClient(io_loop).fetch(request)
     return response
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,405 @@
 {
   "name": "jupyter_server",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "jupyter_server",
+      "version": "1.0.0",
+      "license": "BSD",
+      "dependencies": {
+        "bootstrap": "^3.4.0",
+        "copyfiles": "^2.4.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/bootstrap": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  },
   "dependencies": {
     "ansi-regex": {
       "version": "5.0.1",
@@ -201,6 +598,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -210,11 +612,6 @@
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "6.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.23.1"
+current = "1.24.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.20.0.dev0"
+current = "1.21.0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.24.0.dev0"
+current = "1.24.0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.18.0.dev0"
+current = "1.17.1"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.23.2"
+current = "1.24.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.18.0"
+current = "1.19.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.23.0"
+current = "1.24.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.20.0.dev0"
+current = "1.19.1"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.21.0"
+current = "1.22.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.24.0.dev0"
+current = "1.23.5"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.19.0"
+current = "1.20.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.24.0.dev0"
+current = "1.23.1"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,6 @@ module = [
     "websocket"
 ]
 ignore_missing_imports = true
+
+[tool.check-wheel-contents]
+ignore = ["W002"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.19.0.dev0"
+current = "1.18.1"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.24.0.dev0"
+current = "1.23.6"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ timeout = 300
 # timeout_method = "thread"
 filterwarnings = [
   "error",
-  "ignore:There is no current event loop:DeprecationWarning",
+  "module:make_current is deprecated:DeprecationWarning",
+  "module:clear_current is deprecated:DeprecationWarning",
+  "module:There is no current event loop:DeprecationWarning",
   "ignore:Passing a schema to Validator.iter_errors:DeprecationWarning",
   "ignore:unclosed <socket.socket:ResourceWarning",
   "ignore:unclosed event loop:ResourceWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.18.0.dev0"
+current = "1.18.0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.19.0.dev0"
+current = "1.19.0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.23.6"
+current = "1.24.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.24.0.dev0"
+current = "1.23.2"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.18.1"
+current = "1.19.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.23.5"
+current = "1.24.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.17.1"
+current = "1.18.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.16.1.dev0"
+current = "1.17.0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.23.4"
+current = "1.24.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.24.0.dev0"
+current = "1.23.4"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.23.3"
+current = "1.24.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.17.0"
+current = "1.18.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ filterwarnings = [
   "ignore:Passing a schema to Validator.iter_errors:DeprecationWarning",
   "ignore:unclosed <socket.socket:ResourceWarning",
   "ignore:unclosed event loop:ResourceWarning",
-  "ignore:run_pre_save_hook is deprecated:DeprecationWarning"
+  "ignore:run_pre_save_hook is deprecated:DeprecationWarning",
+  "module:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
 ]
 
 [tool.jupyter-releaser]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,46 @@ default = ""
 [[tool.tbump.field]]
 name = "release"
 default = ""
+
+[tool.mypy]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+no_implicit_optional = true
+pretty = true
+show_error_context = true
+show_error_codes = true
+strict_equality = true
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+exclude = [
+    "examples/simple/setup.py",
+]
+
+
+[[tool.mypy.overrides]]
+module = [
+    "traitlets",
+    "traitlets.config",
+    "traitlets.config.application",
+    "traitlets.config.configurable",
+    "traitlets.tests.utils",
+    "traitlets.utils.importstring",
+    "traitlets.traitlets",
+    "traitlets.utils.descriptions",
+    "jupyter_core",
+    "jupyter_core.application",
+    "jupyter_core.paths",
+    "jupyter_core.utils",
+    "nbconvert.exporters",
+    "nbconvert.exporters.base",
+    "nbformat",
+    "nbformat.sign",
+    "nbformat.v4",
+    "pysqlite2",
+    "_frozen_importlib_external",
+    "send2trash",
+    "terminado",
+    "websocket"
+]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.19.1"
+current = "1.20.0.dev0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.22.0.dev0"
+current = "1.23.0"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ tag_template = "v{new_version}"
 src = "jupyter_server/_version.py"
 version_template = '({major}, {minor}, {patch}, "{channel}", "{release}")'
 
+[[tool.tbump.file]]
+src = "docs/source/conf.py"
+version_template = "{major}.{minor}.{patch}{channel}{release}"
+
 [[tool.tbump.field]]
 name = "channel"
 default = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ skip = ["check-links"]
 post-version-spec = "dev"
 
 [tool.tbump.version]
-current = "1.24.0.dev0"
+current = "1.23.3"
 regex = '''
   (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
   ((?P<channel>a|b|rc|.dev)(?P<release>\d+))?

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,9 +3,3 @@ sphinx:
   configuration: docs/source/conf.py
 conda:
   environment: docs/environment.yml
-python:
-  version: 3.8
-  install:
-    # install itself with pip install .
-    - method: pip
-      path: .

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     argon2-cffi
     jinja2
     jupyter_client>=6.1.12
-    jupyter_core>=4.7.0
+    jupyter_core>=4.12,!=5.0.*
     nbconvert>=6.4.4
     nbformat>=5.2.0
     packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ test =
     pytest-mock
     pytest-timeout
     pytest-tornasync
-    pytest>=6.0
+    pytest>=7.0
     requests
     requests
 

--- a/tests/auth/test_authorizer.py
+++ b/tests/auth/test_authorizer.py
@@ -18,7 +18,7 @@ class AuthorizerforTesting(Authorizer):
     # Set these class attributes from within a test
     # to verify that they match the arguments passed
     # by the REST API.
-    permissions = {}
+    permissions: dict = {}
 
     def normalize_url(self, path):
         """Drop the base URL and make sure path leads with a /"""

--- a/tests/auth/test_authorizer.py
+++ b/tests/auth/test_authorizer.py
@@ -205,7 +205,6 @@ async def test_authorized_requests(
     send_request,
     tmp_path,
     jp_serverapp,
-    jp_cleanup_subprocesses,
     method,
     url,
     body,
@@ -275,5 +274,3 @@ async def test_authorized_requests(
 
     code = await send_request(url, body=body, method=method)
     assert code in expected_codes
-
-    await jp_cleanup_subprocesses()

--- a/tests/auth/test_login.py
+++ b/tests/auth/test_login.py
@@ -48,6 +48,7 @@ async def _login(jp_serverapp, http_server_client, jp_base_url, next):
     except HTTPClientError as e:
         if e.code != 302:
             raise
+        assert e.response is not None
         return e.response.headers["Location"]
     else:
         assert resp.code == 302, "Should have returned a redirect!"

--- a/tests/extension/mockextensions/mockext_deprecated.py
+++ b/tests/extension/mockextensions/mockext_deprecated.py
@@ -1,0 +1,12 @@
+"""A mock extension named `mockext_py` for testing purposes.
+"""
+# Function that makes these extensions discoverable
+# by the test functions.
+
+
+def _jupyter_server_extension_paths():
+    return [{"module": "tests.extension.mockextensions.mockext_deprecated"}]
+
+
+def load_jupyter_server_extension(serverapp):
+    pass

--- a/tests/extension/test_app.py
+++ b/tests/extension/test_app.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from traitlets.config import Config
 
@@ -78,7 +80,7 @@ def test_extensionapp_no_parent():
     assert app.serverapp is not None
 
 
-OPEN_BROWSER_COMBINATIONS = (
+OPEN_BROWSER_COMBINATIONS: Any = (
     (True, {}),
     (True, {"ServerApp": {"open_browser": True}}),
     (False, {"ServerApp": {"open_browser": False}}),

--- a/tests/extension/test_app.py
+++ b/tests/extension/test_app.py
@@ -161,8 +161,8 @@ def test_stop_extension(jp_serverapp, caplog):
     run_sync(jp_serverapp.cleanup_extensions())
     assert [msg for *_, msg in caplog.record_tuples] == [
         "Shutting down 1 extension",
-        f'{extension_name} | extension app "mockextension" stopping',
-        f'{extension_name} | extension app "mockextension" stopped',
+        f"{extension_name} | extension app 'mockextension' stopping",
+        f"{extension_name} | extension app 'mockextension' stopped",
     ]
 
     # check the shutdown method was called once

--- a/tests/extension/test_utils.py
+++ b/tests/extension/test_utils.py
@@ -1,6 +1,11 @@
 import pytest
 
-from jupyter_server.extension.utils import validate_extension
+from jupyter_server.extension.utils import (
+    ExtensionLoadingError,
+    get_loader,
+    validate_extension,
+)
+from tests.extension.mockextensions import mockext_deprecated, mockext_sys
 
 # Use ServerApps environment because it monkeypatches
 # jupyter_core.paths and provides a config directory
@@ -17,3 +22,11 @@ def test_validate_extension():
     assert validate_extension("tests.extension.mockextensions.mockext_user")
     # enabled at Python
     assert validate_extension("tests.extension.mockextensions.mockext_py")
+
+
+def test_get_loader():
+    assert get_loader(mockext_sys) == mockext_sys._load_jupyter_server_extension
+    with pytest.deprecated_call():
+        assert get_loader(mockext_deprecated) == mockext_deprecated.load_jupyter_server_extension
+    with pytest.raises(ExtensionLoadingError):
+        get_loader(object())

--- a/tests/nbconvert/test_handlers.py
+++ b/tests/nbconvert/test_handlers.py
@@ -3,9 +3,9 @@ from base64 import encodebytes
 from shutil import which
 
 import pytest
-import tornado
 from nbformat import writes
 from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook, new_output
+from tornado.httpclient import HTTPClientError
 
 from ..utils import expected_http_error
 
@@ -75,7 +75,7 @@ async def test_from_file(jp_fetch, notebook):
 
 
 async def test_from_file_404(jp_fetch, notebook):
-    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
+    with pytest.raises(HTTPClientError) as e:
         await jp_fetch(
             "nbconvert",
             "html",

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -230,10 +230,11 @@ async def test_get_text_file_contents(jp_fetch, contents, path, name):
         )
     assert expected_http_error(e, 400)
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Disabled retrieving hidden files on Windows")
 async def test_get_404_hidden(jp_fetch, contents, contents_dir):
     # Create text files
-    hidden_dir = contents_dir / '.hidden'
+    hidden_dir = contents_dir / ".hidden"
     hidden_dir.mkdir(parents=True, exist_ok=True)
     txt = f"visible text file in hidden dir"
     txtname = hidden_dir.joinpath(f"visible.txt")
@@ -242,7 +243,7 @@ async def test_get_404_hidden(jp_fetch, contents, contents_dir):
     txt2 = f"hidden text file"
     txtname2 = contents_dir.joinpath(f".hidden.txt")
     txtname2.write_text(txt2, encoding="utf-8")
-   
+
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch(
             "api",
@@ -260,6 +261,7 @@ async def test_get_404_hidden(jp_fetch, contents, contents_dir):
             method="GET",
         )
     assert expected_http_error(e, 404)
+
 
 @pytest.mark.parametrize("path,name", dirs)
 async def test_get_binary_file_contents(jp_fetch, contents, path, name):
@@ -441,48 +443,38 @@ async def test_upload_txt(jp_fetch, contents, contents_dir, _check_created):
 @pytest.mark.skipif(sys.platform == "win32", reason="Disabled uploading hidden files on Windows")
 async def test_upload_txt_hidden(jp_fetch, contents, contents_dir):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        body = 'ünicode téxt'
+        body = "ünicode téxt"
         model = {
-            'content' : body,
-            'format'  : 'text',
-            'type'    : 'file',
+            "content": body,
+            "format": "text",
+            "type": "file",
         }
-        path = '.hidden/Upload tést.txt'
+        path = ".hidden/Upload tést.txt"
         await jp_fetch("api", "contents", path, method="PUT", body=json.dumps(model))
     assert expected_http_error(e, 400)
 
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        body = 'ünicode téxt'
-        model = {
-            'content' : body,
-            'format'  : 'text',
-            'type'    : 'file',
-            'path': '.hidden/test.txt'
-        }
-        path = 'Upload tést.txt'
+        body = "ünicode téxt"
+        model = {"content": body, "format": "text", "type": "file", "path": ".hidden/test.txt"}
+        path = "Upload tést.txt"
         await jp_fetch("api", "contents", path, method="PUT", body=json.dumps(model))
     assert expected_http_error(e, 400)
 
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        body = 'ünicode téxt'
+        body = "ünicode téxt"
         model = {
-            'content' : body,
-            'format'  : 'text',
-            'type'    : 'file',
+            "content": body,
+            "format": "text",
+            "type": "file",
         }
-        path = '.hidden.txt'
+        path = ".hidden.txt"
         await jp_fetch("api", "contents", path, method="PUT", body=json.dumps(model))
     assert expected_http_error(e, 400)
 
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        body = 'ünicode téxt'
-        model = {
-            'content' : body,
-            'format'  : 'text',
-            'type'    : 'file',
-            'path': '.hidden.txt'
-        }
-        path = 'Upload tést.txt'
+        body = "ünicode téxt"
+        model = {"content": body, "format": "text", "type": "file", "path": ".hidden.txt"}
+        path = "Upload tést.txt"
         await jp_fetch("api", "contents", path, method="PUT", body=json.dumps(model))
     assert expected_http_error(e, 400)
 
@@ -581,7 +573,11 @@ async def test_copy_put_400(jp_fetch, contents, contents_dir, _check_created):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Disabled copying hidden files on Windows")
-async def test_copy_put_400_hidden(jp_fetch, contents, contents_dir,):
+async def test_copy_put_400_hidden(
+    jp_fetch,
+    contents,
+    contents_dir,
+):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch(
             "api",
@@ -591,7 +587,7 @@ async def test_copy_put_400_hidden(jp_fetch, contents, contents_dir,):
             body=json.dumps({"copy_from": "new.txt"}),
         )
     assert expected_http_error(e, 400)
-    
+
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch(
             "api",
@@ -601,7 +597,7 @@ async def test_copy_put_400_hidden(jp_fetch, contents, contents_dir,):
             body=json.dumps({"copy_from": ".hidden/new.txt"}),
         )
     assert expected_http_error(e, 400)
-    
+
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch(
             "api",
@@ -611,7 +607,7 @@ async def test_copy_put_400_hidden(jp_fetch, contents, contents_dir,):
             body=json.dumps({"copy_from": "new.txt"}),
         )
     assert expected_http_error(e, 400)
-    
+
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch(
             "api",
@@ -636,16 +632,20 @@ async def test_copy_dir_400(jp_fetch, contents, contents_dir, _check_created):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Disabled copying hidden files on Windows")
-async def test_copy_400_hidden(jp_fetch, contents, contents_dir,):
+async def test_copy_400_hidden(
+    jp_fetch,
+    contents,
+    contents_dir,
+):
 
     # Create text files
-    hidden_dir = contents_dir / '.hidden'
+    hidden_dir = contents_dir / ".hidden"
     hidden_dir.mkdir(parents=True, exist_ok=True)
     txt = f"visible text file in hidden dir"
     txtname = hidden_dir.joinpath(f"new.txt")
     txtname.write_text(txt, encoding="utf-8")
 
-    paths = ['new.txt', '.hidden.txt']
+    paths = ["new.txt", ".hidden.txt"]
     for name in paths:
         txt = f"{name} text file"
         txtname = contents_dir.joinpath(f"{name}.txt")
@@ -660,7 +660,7 @@ async def test_copy_400_hidden(jp_fetch, contents, contents_dir,):
             body=json.dumps({"copy_from": "new.txt"}),
         )
     assert expected_http_error(e, 400)
-    
+
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch(
             "api",
@@ -689,7 +689,7 @@ async def test_copy_400_hidden(jp_fetch, contents, contents_dir,):
             method="POST",
             body=json.dumps({"copy_from": ".hidden.txt"}),
         )
-    assert expected_http_error(e, 400)    
+    assert expected_http_error(e, 400)
 
 
 @pytest.mark.parametrize("path,name", dirs)
@@ -729,20 +729,22 @@ async def test_delete_non_empty_dir(jp_fetch, contents):
         await jp_fetch("api", "contents", "å b", method="GET")
     assert expected_http_error(e, 404)
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Disabled deleting hidden dirs on Windows")
 async def test_delete_hidden_dir(jp_fetch, contents):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch("api", "contents", ".hidden", method="DELETE")
     assert expected_http_error(e, 400)
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Disabled deleting hidden dirs on Windows")
 async def test_delete_hidden_file(jp_fetch, contents):
-    #Test deleting file in a hidden directory
+    # Test deleting file in a hidden directory
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch("api", "contents", ".hidden/test.txt", method="DELETE")
     assert expected_http_error(e, 400)
 
-    #Test deleting a hidden file
+    # Test deleting a hidden file
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch("api", "contents", ".hidden.txt", method="DELETE")
     assert expected_http_error(e, 400)
@@ -778,37 +780,12 @@ async def test_rename(jp_fetch, jp_base_url, contents, contents_dir):
     assert "z.ipynb" in nbnames
     assert "a.ipynb" not in nbnames
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Disabled copying hidden files on Windows")
 async def test_rename_400_hidden(jp_fetch, jp_base_url, contents, contents_dir):
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        old_path = '.hidden/old.txt'
-        new_path = 'new.txt'
-        # Rename the file
-        r = await jp_fetch(
-            "api",
-            "contents",
-            old_path,
-            method="PATCH",
-            body=json.dumps({"path": new_path}),
-        )
-    assert expected_http_error(e, 400)
-        
-    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        old_path = 'old.txt'
-        new_path = '.hidden/new.txt'
-        # Rename the file
-        r = await jp_fetch(
-            "api",
-            "contents",
-            old_path,
-            method="PATCH",
-            body=json.dumps({"path": new_path}),
-        )
-    assert expected_http_error(e, 400)
-        
-    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        old_path = '.hidden.txt'
-        new_path = 'new.txt'
+        old_path = ".hidden/old.txt"
+        new_path = "new.txt"
         # Rename the file
         r = await jp_fetch(
             "api",
@@ -820,8 +797,34 @@ async def test_rename_400_hidden(jp_fetch, jp_base_url, contents, contents_dir):
     assert expected_http_error(e, 400)
 
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
-        old_path = 'old.txt'
-        new_path = '.hidden.txt'
+        old_path = "old.txt"
+        new_path = ".hidden/new.txt"
+        # Rename the file
+        r = await jp_fetch(
+            "api",
+            "contents",
+            old_path,
+            method="PATCH",
+            body=json.dumps({"path": new_path}),
+        )
+    assert expected_http_error(e, 400)
+
+    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
+        old_path = ".hidden.txt"
+        new_path = "new.txt"
+        # Rename the file
+        r = await jp_fetch(
+            "api",
+            "contents",
+            old_path,
+            method="PATCH",
+            body=json.dumps({"path": new_path}),
+        )
+    assert expected_http_error(e, 400)
+
+    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
+        old_path = "old.txt"
+        new_path = ".hidden.txt"
         # Rename the file
         r = await jp_fetch(
             "api",

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -236,12 +236,12 @@ async def test_get_404_hidden(jp_fetch, contents, contents_dir):
     # Create text files
     hidden_dir = contents_dir / ".hidden"
     hidden_dir.mkdir(parents=True, exist_ok=True)
-    txt = f"visible text file in hidden dir"
-    txtname = hidden_dir.joinpath(f"visible.txt")
+    txt = "visible text file in hidden dir"
+    txtname = hidden_dir.joinpath("visible.txt")
     txtname.write_text(txt, encoding="utf-8")
 
-    txt2 = f"hidden text file"
-    txtname2 = contents_dir.joinpath(f".hidden.txt")
+    txt2 = "hidden text file"
+    txtname2 = contents_dir.joinpath(".hidden.txt")
     txtname2.write_text(txt2, encoding="utf-8")
 
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
@@ -641,8 +641,8 @@ async def test_copy_400_hidden(
     # Create text files
     hidden_dir = contents_dir / ".hidden"
     hidden_dir.mkdir(parents=True, exist_ok=True)
-    txt = f"visible text file in hidden dir"
-    txtname = hidden_dir.joinpath(f"new.txt")
+    txt = "visible text file in hidden dir"
+    txtname = hidden_dir.joinpath("new.txt")
     txtname.write_text(txt, encoding="utf-8")
 
     paths = ["new.txt", ".hidden.txt"]

--- a/tests/services/contents/test_api.py
+++ b/tests/services/contents/test_api.py
@@ -54,7 +54,7 @@ def contents_dir(tmp_path, jp_serverapp):
 @pytest.fixture
 def contents(contents_dir):
     # Create files in temporary directory
-    paths = {
+    paths: dict = {
         "notebooks": [],
         "textfiles": [],
         "blobs": [],

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -77,7 +77,7 @@ def add_invalid_cell(notebook):
 
 
 async def prepare_notebook(
-    jp_contents_manager, make_invalid: Optional[bool] = False
+    jp_contents_manager: FileContentsManager, make_invalid: Optional[bool] = False
 ) -> Tuple[Dict, str]:
     cm = jp_contents_manager
     model = await ensure_async(cm.new_untitled(type="notebook"))
@@ -756,7 +756,7 @@ async def test_validate_notebook_model(jp_contents_manager):
     with patch("jupyter_server.services.contents.manager.validate_nb") as mock_validate_nb:
         # Valid notebook and a non-None dictionary, no validate call expected
 
-        validation_error = {}
+        validation_error: dict = {}
         cm.validate_notebook_model(model, validation_error)
         assert mock_validate_nb.call_count == 0
         mock_validate_nb.reset_mock()

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -259,80 +259,81 @@ async def test_403(jp_file_contents_manager_class, tmp_path):
     except HTTPError as e:
         assert e.status_code == 403
 
-@pytest.mark.skipif(sys.platform.startswith('win'), reason="Can't test hidden files on Windows")
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Can't test hidden files on Windows")
 async def test_400(jp_file_contents_manager_class, tmp_path):
-    #Test Delete behavior
-    #Test delete of file in hidden directory
+    # Test Delete behavior
+    # Test delete of file in hidden directory
     with pytest.raises(HTTPError) as excinfo:
         td = str(tmp_path)
         cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = '.hidden'
-        file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+        hidden_dir = ".hidden"
+        file_in_hidden_path = os.path.join(hidden_dir, "visible.txt")
         _make_dir(cm, hidden_dir)
         model = await ensure_async(cm.new(path=file_in_hidden_path))
-        os_path = cm._get_os_path(model['path'])
+        os_path = cm._get_os_path(model["path"])
 
         try:
             result = await ensure_async(cm.delete_file(os_path))
         except HTTPError as e:
             assert e.status_code == 400
 
-    #Test delete hidden file in visible directory
+    # Test delete hidden file in visible directory
     with pytest.raises(HTTPError) as excinfo:
         td = str(tmp_path)
         cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = 'visible'
-        file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+        hidden_dir = "visible"
+        file_in_hidden_path = os.path.join(hidden_dir, ".hidden.txt")
         _make_dir(cm, hidden_dir)
         model = await ensure_async(cm.new(path=file_in_hidden_path))
-        os_path = cm._get_os_path(model['path'])
+        os_path = cm._get_os_path(model["path"])
 
         try:
             result = await ensure_async(cm.delete_file(os_path))
         except HTTPError as e:
             assert e.status_code == 400
 
-    #Test Save behavior
-    #Test save of file in hidden directory
+    # Test Save behavior
+    # Test save of file in hidden directory
     with pytest.raises(HTTPError) as excinfo:
         td = str(tmp_path)
         cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = '.hidden'
-        file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+        hidden_dir = ".hidden"
+        file_in_hidden_path = os.path.join(hidden_dir, "visible.txt")
         _make_dir(cm, hidden_dir)
         model = await ensure_async(cm.new(path=file_in_hidden_path))
-        os_path = cm._get_os_path(model['path'])
+        os_path = cm._get_os_path(model["path"])
 
         try:
-            result = await ensure_async(cm.save(model,path=os_path))
+            result = await ensure_async(cm.save(model, path=os_path))
         except HTTPError as e:
             assert e.status_code == 400
 
-    #Test save hidden file in visible directory
+    # Test save hidden file in visible directory
     with pytest.raises(HTTPError) as excinfo:
         td = str(tmp_path)
         cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = 'visible'
-        file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+        hidden_dir = "visible"
+        file_in_hidden_path = os.path.join(hidden_dir, ".hidden.txt")
         _make_dir(cm, hidden_dir)
         model = await ensure_async(cm.new(path=file_in_hidden_path))
-        os_path = cm._get_os_path(model['path'])
+        os_path = cm._get_os_path(model["path"])
 
         try:
-            result = await ensure_async(cm.save(model,path=os_path))
+            result = await ensure_async(cm.save(model, path=os_path))
         except HTTPError as e:
             assert e.status_code == 400
 
-    #Test rename behavior
-    #Test rename with source file in hidden directory
+    # Test rename behavior
+    # Test rename with source file in hidden directory
     with pytest.raises(HTTPError) as excinfo:
         td = str(tmp_path)
         cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = '.hidden'
-        file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+        hidden_dir = ".hidden"
+        file_in_hidden_path = os.path.join(hidden_dir, "visible.txt")
         _make_dir(cm, hidden_dir)
         model = await ensure_async(cm.new(path=file_in_hidden_path))
-        old_path = cm._get_os_path(model['path'])
+        old_path = cm._get_os_path(model["path"])
         new_path = "new.txt"
 
         try:
@@ -340,15 +341,15 @@ async def test_400(jp_file_contents_manager_class, tmp_path):
         except HTTPError as e:
             assert e.status_code == 400
 
-    #Test rename of dest file in hidden directory
+    # Test rename of dest file in hidden directory
     with pytest.raises(HTTPError) as excinfo:
         td = str(tmp_path)
         cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = '.hidden'
-        file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+        hidden_dir = ".hidden"
+        file_in_hidden_path = os.path.join(hidden_dir, "visible.txt")
         _make_dir(cm, hidden_dir)
         model = await ensure_async(cm.new(path=file_in_hidden_path))
-        new_path = cm._get_os_path(model['path'])
+        new_path = cm._get_os_path(model["path"])
         old_path = "old.txt"
 
         try:
@@ -356,15 +357,15 @@ async def test_400(jp_file_contents_manager_class, tmp_path):
         except HTTPError as e:
             assert e.status_code == 400
 
-    #Test rename with hidden source file in visible directory
+    # Test rename with hidden source file in visible directory
     with pytest.raises(HTTPError) as excinfo:
         td = str(tmp_path)
         cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = 'visible'
-        file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+        hidden_dir = "visible"
+        file_in_hidden_path = os.path.join(hidden_dir, ".hidden.txt")
         _make_dir(cm, hidden_dir)
         model = await ensure_async(cm.new(path=file_in_hidden_path))
-        old_path = cm._get_os_path(model['path'])
+        old_path = cm._get_os_path(model["path"])
         new_path = "new.txt"
 
         try:
@@ -372,15 +373,15 @@ async def test_400(jp_file_contents_manager_class, tmp_path):
         except HTTPError as e:
             assert e.status_code == 400
 
-    #Test rename with hidden dest file in visible directory
+    # Test rename with hidden dest file in visible directory
     with pytest.raises(HTTPError) as excinfo:
         td = str(tmp_path)
         cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = 'visible'
-        file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+        hidden_dir = "visible"
+        file_in_hidden_path = os.path.join(hidden_dir, ".hidden.txt")
         _make_dir(cm, hidden_dir)
         model = await ensure_async(cm.new(path=file_in_hidden_path))
-        new_path = cm._get_os_path(model['path'])
+        new_path = cm._get_os_path(model["path"])
         old_path = "old.txt"
 
         try:
@@ -388,37 +389,39 @@ async def test_400(jp_file_contents_manager_class, tmp_path):
         except HTTPError as e:
             assert e.status_code == 400
 
-@pytest.mark.skipif(sys.platform.startswith('win'), reason="Can't test hidden files on Windows")
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Can't test hidden files on Windows")
 async def test_404(jp_file_contents_manager_class, tmp_path):
-    #Test visible file in hidden folder
+    # Test visible file in hidden folder
     with pytest.raises(HTTPError) as excinfo:
         td = str(tmp_path)
         cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = '.hidden'
-        file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+        hidden_dir = ".hidden"
+        file_in_hidden_path = os.path.join(hidden_dir, "visible.txt")
         _make_dir(cm, hidden_dir)
         model = await ensure_async(cm.new(path=file_in_hidden_path))
-        os_path = cm._get_os_path(model['path'])
+        os_path = cm._get_os_path(model["path"])
 
         try:
-            result = await ensure_async(cm.get(os_path, 'w'))
+            result = await ensure_async(cm.get(os_path, "w"))
         except HTTPError as e:
             assert e.status_code == 404
 
-    #Test hidden file in visible folder
+    # Test hidden file in visible folder
     with pytest.raises(HTTPError) as excinfo:
         td = str(tmp_path)
         cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = 'visible'
-        file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+        hidden_dir = "visible"
+        file_in_hidden_path = os.path.join(hidden_dir, ".hidden.txt")
         _make_dir(cm, hidden_dir)
         model = await ensure_async(cm.new(path=file_in_hidden_path))
-        os_path = cm._get_os_path(model['path'])
+        os_path = cm._get_os_path(model["path"])
 
         try:
-            result = await ensure_async(cm.get(os_path, 'w'))
+            result = await ensure_async(cm.get(os_path, "w"))
         except HTTPError as e:
             assert e.status_code == 404
+
 
 async def test_escape_root(jp_file_contents_manager_class, tmp_path):
     td = str(tmp_path)

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -264,34 +264,26 @@ async def test_403(jp_file_contents_manager_class, tmp_path):
 async def test_400(jp_file_contents_manager_class, tmp_path):
     # Test Delete behavior
     # Test delete of file in hidden directory
-    with pytest.raises(HTTPError) as excinfo:
-        td = str(tmp_path)
-        cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = ".hidden"
-        file_in_hidden_path = os.path.join(hidden_dir, "visible.txt")
-        _make_dir(cm, hidden_dir)
-        model = await ensure_async(cm.new(path=file_in_hidden_path))
-        os_path = cm._get_os_path(model["path"])
+    td = str(tmp_path)
+    cm = jp_file_contents_manager_class(root_dir=td)
+    hidden_dir = ".hidden"
+    file_in_hidden_path = os.path.join(hidden_dir, "visible.txt")
+    _make_dir(cm, hidden_dir)
 
-        try:
-            result = await ensure_async(cm.delete_file(os_path))
-        except HTTPError as e:
-            assert e.status_code == 400
+    with pytest.raises(HTTPError) as excinfo:
+        await ensure_async(cm.delete_file(file_in_hidden_path))
+    assert excinfo.value.status_code == 400
 
     # Test delete hidden file in visible directory
-    with pytest.raises(HTTPError) as excinfo:
-        td = str(tmp_path)
-        cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = "visible"
-        file_in_hidden_path = os.path.join(hidden_dir, ".hidden.txt")
-        _make_dir(cm, hidden_dir)
-        model = await ensure_async(cm.new(path=file_in_hidden_path))
-        os_path = cm._get_os_path(model["path"])
+    td = str(tmp_path)
+    cm = jp_file_contents_manager_class(root_dir=td)
+    hidden_dir = "visible"
+    file_in_hidden_path = os.path.join(hidden_dir, ".hidden.txt")
+    _make_dir(cm, hidden_dir)
 
-        try:
-            result = await ensure_async(cm.delete_file(os_path))
-        except HTTPError as e:
-            assert e.status_code == 400
+    with pytest.raises(HTTPError) as excinfo:
+        await ensure_async(cm.delete_file(file_in_hidden_path))
+    assert excinfo.value.status_code == 400
 
     # Test Save behavior
     # Test save of file in hidden directory
@@ -326,68 +318,56 @@ async def test_400(jp_file_contents_manager_class, tmp_path):
 
     # Test rename behavior
     # Test rename with source file in hidden directory
-    with pytest.raises(HTTPError) as excinfo:
-        td = str(tmp_path)
-        cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = ".hidden"
-        file_in_hidden_path = os.path.join(hidden_dir, "visible.txt")
-        _make_dir(cm, hidden_dir)
-        model = await ensure_async(cm.new(path=file_in_hidden_path))
-        old_path = cm._get_os_path(model["path"])
-        new_path = "new.txt"
+    td = str(tmp_path)
+    cm = jp_file_contents_manager_class(root_dir=td)
+    hidden_dir = ".hidden"
+    file_in_hidden_path = os.path.join(hidden_dir, "visible.txt")
+    _make_dir(cm, hidden_dir)
+    old_path = file_in_hidden_path
+    new_path = "new.txt"
 
-        try:
-            result = await ensure_async(cm.rename_file(old_path, new_path))
-        except HTTPError as e:
-            assert e.status_code == 400
+    with pytest.raises(HTTPError) as excinfo:
+        await ensure_async(cm.rename_file(old_path, new_path))
+    assert excinfo.value.status_code == 400
 
     # Test rename of dest file in hidden directory
-    with pytest.raises(HTTPError) as excinfo:
-        td = str(tmp_path)
-        cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = ".hidden"
-        file_in_hidden_path = os.path.join(hidden_dir, "visible.txt")
-        _make_dir(cm, hidden_dir)
-        model = await ensure_async(cm.new(path=file_in_hidden_path))
-        new_path = cm._get_os_path(model["path"])
-        old_path = "old.txt"
+    td = str(tmp_path)
+    cm = jp_file_contents_manager_class(root_dir=td)
+    hidden_dir = ".hidden"
+    file_in_hidden_path = os.path.join(hidden_dir, "visible.txt")
+    _make_dir(cm, hidden_dir)
+    new_path = file_in_hidden_path
+    old_path = "old.txt"
 
-        try:
-            result = await ensure_async(cm.rename_file(old_path, new_path))
-        except HTTPError as e:
-            assert e.status_code == 400
+    with pytest.raises(HTTPError) as excinfo:
+        await ensure_async(cm.rename_file(old_path, new_path))
+    assert excinfo.value.status_code == 400
 
     # Test rename with hidden source file in visible directory
-    with pytest.raises(HTTPError) as excinfo:
-        td = str(tmp_path)
-        cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = "visible"
-        file_in_hidden_path = os.path.join(hidden_dir, ".hidden.txt")
-        _make_dir(cm, hidden_dir)
-        model = await ensure_async(cm.new(path=file_in_hidden_path))
-        old_path = cm._get_os_path(model["path"])
-        new_path = "new.txt"
+    td = str(tmp_path)
+    cm = jp_file_contents_manager_class(root_dir=td)
+    hidden_dir = "visible"
+    file_in_hidden_path = os.path.join(hidden_dir, ".hidden.txt")
+    _make_dir(cm, hidden_dir)
+    old_path = file_in_hidden_path
+    new_path = "new.txt"
 
-        try:
-            result = await ensure_async(cm.rename_file(old_path, new_path))
-        except HTTPError as e:
-            assert e.status_code == 400
+    with pytest.raises(HTTPError) as excinfo:
+        await ensure_async(cm.rename_file(old_path, new_path))
+    assert excinfo.value.status_code == 400
 
     # Test rename with hidden dest file in visible directory
-    with pytest.raises(HTTPError) as excinfo:
-        td = str(tmp_path)
-        cm = jp_file_contents_manager_class(root_dir=td)
-        hidden_dir = "visible"
-        file_in_hidden_path = os.path.join(hidden_dir, ".hidden.txt")
-        _make_dir(cm, hidden_dir)
-        model = await ensure_async(cm.new(path=file_in_hidden_path))
-        new_path = cm._get_os_path(model["path"])
-        old_path = "old.txt"
+    td = str(tmp_path)
+    cm = jp_file_contents_manager_class(root_dir=td)
+    hidden_dir = "visible"
+    file_in_hidden_path = os.path.join(hidden_dir, ".hidden.txt")
+    _make_dir(cm, hidden_dir)
+    new_path = file_in_hidden_path
+    old_path = "old.txt"
 
-        try:
-            result = await ensure_async(cm.rename_file(old_path, new_path))
-        except HTTPError as e:
-            assert e.status_code == 400
+    with pytest.raises(HTTPError) as excinfo:
+        await ensure_async(cm.rename_file(old_path, new_path))
+    assert excinfo.value.status_code == 400
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Can't test hidden files on Windows")

--- a/tests/services/contents/test_manager.py
+++ b/tests/services/contents/test_manager.py
@@ -259,6 +259,166 @@ async def test_403(jp_file_contents_manager_class, tmp_path):
     except HTTPError as e:
         assert e.status_code == 403
 
+@pytest.mark.skipif(sys.platform.startswith('win'), reason="Can't test hidden files on Windows")
+async def test_400(jp_file_contents_manager_class, tmp_path):
+    #Test Delete behavior
+    #Test delete of file in hidden directory
+    with pytest.raises(HTTPError) as excinfo:
+        td = str(tmp_path)
+        cm = jp_file_contents_manager_class(root_dir=td)
+        hidden_dir = '.hidden'
+        file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+        _make_dir(cm, hidden_dir)
+        model = await ensure_async(cm.new(path=file_in_hidden_path))
+        os_path = cm._get_os_path(model['path'])
+
+        try:
+            result = await ensure_async(cm.delete_file(os_path))
+        except HTTPError as e:
+            assert e.status_code == 400
+
+    #Test delete hidden file in visible directory
+    with pytest.raises(HTTPError) as excinfo:
+        td = str(tmp_path)
+        cm = jp_file_contents_manager_class(root_dir=td)
+        hidden_dir = 'visible'
+        file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+        _make_dir(cm, hidden_dir)
+        model = await ensure_async(cm.new(path=file_in_hidden_path))
+        os_path = cm._get_os_path(model['path'])
+
+        try:
+            result = await ensure_async(cm.delete_file(os_path))
+        except HTTPError as e:
+            assert e.status_code == 400
+
+    #Test Save behavior
+    #Test save of file in hidden directory
+    with pytest.raises(HTTPError) as excinfo:
+        td = str(tmp_path)
+        cm = jp_file_contents_manager_class(root_dir=td)
+        hidden_dir = '.hidden'
+        file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+        _make_dir(cm, hidden_dir)
+        model = await ensure_async(cm.new(path=file_in_hidden_path))
+        os_path = cm._get_os_path(model['path'])
+
+        try:
+            result = await ensure_async(cm.save(model,path=os_path))
+        except HTTPError as e:
+            assert e.status_code == 400
+
+    #Test save hidden file in visible directory
+    with pytest.raises(HTTPError) as excinfo:
+        td = str(tmp_path)
+        cm = jp_file_contents_manager_class(root_dir=td)
+        hidden_dir = 'visible'
+        file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+        _make_dir(cm, hidden_dir)
+        model = await ensure_async(cm.new(path=file_in_hidden_path))
+        os_path = cm._get_os_path(model['path'])
+
+        try:
+            result = await ensure_async(cm.save(model,path=os_path))
+        except HTTPError as e:
+            assert e.status_code == 400
+
+    #Test rename behavior
+    #Test rename with source file in hidden directory
+    with pytest.raises(HTTPError) as excinfo:
+        td = str(tmp_path)
+        cm = jp_file_contents_manager_class(root_dir=td)
+        hidden_dir = '.hidden'
+        file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+        _make_dir(cm, hidden_dir)
+        model = await ensure_async(cm.new(path=file_in_hidden_path))
+        old_path = cm._get_os_path(model['path'])
+        new_path = "new.txt"
+
+        try:
+            result = await ensure_async(cm.rename_file(old_path, new_path))
+        except HTTPError as e:
+            assert e.status_code == 400
+
+    #Test rename of dest file in hidden directory
+    with pytest.raises(HTTPError) as excinfo:
+        td = str(tmp_path)
+        cm = jp_file_contents_manager_class(root_dir=td)
+        hidden_dir = '.hidden'
+        file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+        _make_dir(cm, hidden_dir)
+        model = await ensure_async(cm.new(path=file_in_hidden_path))
+        new_path = cm._get_os_path(model['path'])
+        old_path = "old.txt"
+
+        try:
+            result = await ensure_async(cm.rename_file(old_path, new_path))
+        except HTTPError as e:
+            assert e.status_code == 400
+
+    #Test rename with hidden source file in visible directory
+    with pytest.raises(HTTPError) as excinfo:
+        td = str(tmp_path)
+        cm = jp_file_contents_manager_class(root_dir=td)
+        hidden_dir = 'visible'
+        file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+        _make_dir(cm, hidden_dir)
+        model = await ensure_async(cm.new(path=file_in_hidden_path))
+        old_path = cm._get_os_path(model['path'])
+        new_path = "new.txt"
+
+        try:
+            result = await ensure_async(cm.rename_file(old_path, new_path))
+        except HTTPError as e:
+            assert e.status_code == 400
+
+    #Test rename with hidden dest file in visible directory
+    with pytest.raises(HTTPError) as excinfo:
+        td = str(tmp_path)
+        cm = jp_file_contents_manager_class(root_dir=td)
+        hidden_dir = 'visible'
+        file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+        _make_dir(cm, hidden_dir)
+        model = await ensure_async(cm.new(path=file_in_hidden_path))
+        new_path = cm._get_os_path(model['path'])
+        old_path = "old.txt"
+
+        try:
+            result = await ensure_async(cm.rename_file(old_path, new_path))
+        except HTTPError as e:
+            assert e.status_code == 400
+
+@pytest.mark.skipif(sys.platform.startswith('win'), reason="Can't test hidden files on Windows")
+async def test_404(jp_file_contents_manager_class, tmp_path):
+    #Test visible file in hidden folder
+    with pytest.raises(HTTPError) as excinfo:
+        td = str(tmp_path)
+        cm = jp_file_contents_manager_class(root_dir=td)
+        hidden_dir = '.hidden'
+        file_in_hidden_path = os.path.join(hidden_dir,'visible.txt')
+        _make_dir(cm, hidden_dir)
+        model = await ensure_async(cm.new(path=file_in_hidden_path))
+        os_path = cm._get_os_path(model['path'])
+
+        try:
+            result = await ensure_async(cm.get(os_path, 'w'))
+        except HTTPError as e:
+            assert e.status_code == 404
+
+    #Test hidden file in visible folder
+    with pytest.raises(HTTPError) as excinfo:
+        td = str(tmp_path)
+        cm = jp_file_contents_manager_class(root_dir=td)
+        hidden_dir = 'visible'
+        file_in_hidden_path = os.path.join(hidden_dir,'.hidden.txt')
+        _make_dir(cm, hidden_dir)
+        model = await ensure_async(cm.new(path=file_in_hidden_path))
+        os_path = cm._get_os_path(model['path'])
+
+        try:
+            result = await ensure_async(cm.get(os_path, 'w'))
+        except HTTPError as e:
+            assert e.status_code == 404
 
 async def test_escape_root(jp_file_contents_manager_class, tmp_path):
     td = str(tmp_path)

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import time
@@ -22,7 +23,10 @@ def pending_kernel_is_ready(jp_serverapp):
         if getattr(km, "use_pending_kernels", False):
             kernel = km.get_kernel(kernel_id)
             if getattr(kernel, "ready", None):
-                await kernel.ready
+                ready = kernel.ready
+                if not isinstance(ready, asyncio.Future):
+                    ready = asyncio.wrap_future(ready)
+                await ready
 
     return _
 

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -67,7 +67,7 @@ async def test_no_kernels(jp_fetch):
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)
-async def test_default_kernels(jp_fetch, jp_base_url, jp_cleanup_subprocesses):
+async def test_default_kernels(jp_fetch, jp_base_url):
     r = await jp_fetch("api", "kernels", method="POST", allow_nonstandard_methods=True)
     kernel = json.loads(r.body.decode())
     assert r.headers["location"] == url_path_join(jp_base_url, "/api/kernels/", kernel["id"])
@@ -79,13 +79,10 @@ async def test_default_kernels(jp_fetch, jp_base_url, jp_cleanup_subprocesses):
         ["frame-ancestors 'self'", "report-uri " + report_uri, "default-src 'none'"]
     )
     assert r.headers["Content-Security-Policy"] == expected_csp
-    await jp_cleanup_subprocesses()
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)
-async def test_main_kernel_handler(
-    jp_fetch, jp_base_url, jp_cleanup_subprocesses, jp_serverapp, pending_kernel_is_ready
-):
+async def test_main_kernel_handler(jp_fetch, jp_base_url, jp_serverapp, pending_kernel_is_ready):
     # Start the first kernel
     r = await jp_fetch(
         "api", "kernels", method="POST", body=json.dumps({"name": NATIVE_KERNEL_NAME})
@@ -158,11 +155,10 @@ async def test_main_kernel_handler(
     )
     kernel3 = json.loads(r.body.decode())
     assert isinstance(kernel3, dict)
-    await jp_cleanup_subprocesses()
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)
-async def test_kernel_handler(jp_fetch, jp_cleanup_subprocesses, pending_kernel_is_ready):
+async def test_kernel_handler(jp_fetch, jp_serverapp, pending_kernel_is_ready):
     # Create a kernel
     r = await jp_fetch(
         "api", "kernels", method="POST", body=json.dumps({"name": NATIVE_KERNEL_NAME})
@@ -206,13 +202,10 @@ async def test_kernel_handler(jp_fetch, jp_cleanup_subprocesses, pending_kernel_
     with pytest.raises(tornado.httpclient.HTTPClientError) as e:
         await jp_fetch("api", "kernels", bad_id, method="DELETE")
     assert expected_http_error(e, 404, "Kernel does not exist: " + bad_id)
-    await jp_cleanup_subprocesses()
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)
-async def test_kernel_handler_startup_error(
-    jp_fetch, jp_cleanup_subprocesses, jp_serverapp, jp_kernelspecs
-):
+async def test_kernel_handler_startup_error(jp_fetch, jp_serverapp, jp_kernelspecs):
     if getattr(jp_serverapp.kernel_manager, "use_pending_kernels", False):
         return
 
@@ -223,7 +216,7 @@ async def test_kernel_handler_startup_error(
 
 @pytest.mark.timeout(TEST_TIMEOUT)
 async def test_kernel_handler_startup_error_pending(
-    jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses, jp_serverapp, jp_kernelspecs
+    jp_fetch, jp_ws_fetch, jp_serverapp, jp_kernelspecs
 ):
     if not getattr(jp_serverapp.kernel_manager, "use_pending_kernels", False):
         return
@@ -238,9 +231,7 @@ async def test_kernel_handler_startup_error_pending(
 
 
 @pytest.mark.timeout(TEST_TIMEOUT)
-async def test_connection(
-    jp_fetch, jp_ws_fetch, jp_http_port, jp_auth_header, jp_cleanup_subprocesses
-):
+async def test_connection(jp_fetch, jp_ws_fetch, jp_http_port, jp_auth_header):
     # Create kernel
     r = await jp_fetch(
         "api", "kernels", method="POST", body=json.dumps({"name": NATIVE_KERNEL_NAME})
@@ -274,4 +265,3 @@ async def test_connection(
     r = await jp_fetch("api", "kernels", kid, method="GET")
     model = json.loads(r.body.decode())
     assert model["connections"] == 0
-    await jp_cleanup_subprocesses()

--- a/tests/services/kernels/test_api.py
+++ b/tests/services/kernels/test_api.py
@@ -27,7 +27,7 @@ def pending_kernel_is_ready(jp_serverapp):
     return _
 
 
-configs = [
+configs: list = [
     {
         "ServerApp": {
             "kernel_manager_class": "jupyter_server.services.kernels.kernelmanager.MappingKernelManager"

--- a/tests/services/kernels/test_cull.py
+++ b/tests/services/kernels/test_cull.py
@@ -43,7 +43,7 @@ CULL_INTERVAL = 1
         ),
     ],
 )
-async def test_cull_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses):
+async def test_cull_idle(jp_fetch, jp_ws_fetch):
     r = await jp_fetch("api", "kernels", method="POST", allow_nonstandard_methods=True)
     kernel = json.loads(r.body.decode())
     kid = kernel["id"]
@@ -59,7 +59,6 @@ async def test_cull_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses):
     ws.close()
     culled = await get_cull_status(kid, jp_fetch)  # not connected, should be culled
     assert culled
-    await jp_cleanup_subprocesses()
 
 
 # Pending kernels was released in Jupyter Client 7.1
@@ -89,9 +88,7 @@ async def test_cull_idle(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses):
     ],
 )
 @pytest.mark.timeout(30)
-async def test_cull_dead(
-    jp_fetch, jp_ws_fetch, jp_serverapp, jp_cleanup_subprocesses, jp_kernelspecs
-):
+async def test_cull_dead(jp_fetch, jp_ws_fetch, jp_serverapp, jp_kernelspecs):
     r = await jp_fetch("api", "kernels", method="POST", allow_nonstandard_methods=True)
     kernel = json.loads(r.body.decode())
     kid = kernel["id"]
@@ -105,7 +102,6 @@ async def test_cull_dead(
     assert model["connections"] == 0
     culled = await get_cull_status(kid, jp_fetch)  # connected, should not be culled
     assert culled
-    await jp_cleanup_subprocesses()
 
 
 async def get_cull_status(kid, jp_fetch):

--- a/tests/services/kernelspecs/test_api.py
+++ b/tests/services/kernelspecs/test_api.py
@@ -1,8 +1,8 @@
 import json
 
 import pytest
-import tornado
 from jupyter_client.kernelspec import NATIVE_KERNEL_NAME
+from tornado.httpclient import HTTPClientError
 
 from ...utils import expected_http_error, some_resource
 
@@ -51,7 +51,7 @@ async def test_get_kernelspecs(jp_fetch, jp_kernelspecs):
 
 
 async def test_get_nonexistant_kernelspec(jp_fetch, jp_kernelspecs):
-    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
+    with pytest.raises(HTTPClientError) as e:
         await jp_fetch("api", "kernelspecs", "nonexistant", method="GET")
     assert expected_http_error(e, 404)
 
@@ -63,10 +63,10 @@ async def test_get_kernel_resource_file(jp_fetch, jp_kernelspecs):
 
 
 async def test_get_nonexistant_resource(jp_fetch, jp_kernelspecs):
-    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
+    with pytest.raises(HTTPClientError) as e:
         await jp_fetch("kernelspecs", "nonexistant", "resource.txt", method="GET")
     assert expected_http_error(e, 404)
 
-    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
+    with pytest.raises(HTTPClientError) as e:
         await jp_fetch("kernelspecs", "sample", "nonexistant.txt", method="GET")
     assert expected_http_error(e, 404)

--- a/tests/services/sessions/test_api.py
+++ b/tests/services/sessions/test_api.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 import time
+from typing import Any
 
 import jupyter_client
 import pytest
@@ -29,7 +30,7 @@ class NewPortsKernelManager(AsyncIOLoopKernelManager):
     def _default_cache_ports(self) -> bool:
         return False
 
-    async def restart_kernel(self, now: bool = False, newports: bool = True, **kw) -> None:
+    async def restart_kernel(self, now: bool = False, newports: bool = True, **kw: Any) -> None:
         self.log.debug(f"DEBUG**** calling super().restart_kernel with newports={newports}")
         return await super().restart_kernel(now=now, newports=newports, **kw)
 
@@ -41,7 +42,7 @@ class NewPortsMappingKernelManager(AsyncMappingKernelManager):
         return "tests.services.sessions.test_api.NewPortsKernelManager"
 
 
-configs = [
+configs: list = [
     {
         "ServerApp": {
             "kernel_manager_class": "jupyter_server.services.kernels.kernelmanager.MappingKernelManager"
@@ -65,7 +66,7 @@ configs = [
 # See https://github.com/jupyter-server/jupyter_server/issues/672
 if os.name != "nt" and jupyter_client._version.version_info >= (7, 1):
     # Add a pending kernels condition
-    c = {
+    c: dict = {
         "ServerApp": {
             "kernel_manager_class": "tests.services.sessions.test_api.NewPortsMappingKernelManager"
         },

--- a/tests/services/sessions/test_api.py
+++ b/tests/services/sessions/test_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import shutil
@@ -163,7 +164,10 @@ def session_is_ready(jp_serverapp):
             kernel_id = session["kernel"]["id"]
             kernel = mkm.get_kernel(kernel_id)
             if getattr(kernel, "ready", None):
-                await kernel.ready
+                ready = kernel.ready
+                if not isinstance(ready, asyncio.Future):
+                    ready = asyncio.wrap_future(ready)
+                await ready
 
     return _
 

--- a/tests/services/sessions/test_manager.py
+++ b/tests/services/sessions/test_manager.py
@@ -16,6 +16,9 @@ from jupyter_server.services.sessions.sessionmanager import (
 
 
 class DummyKernel:
+    execution_state: str
+    last_activity: str
+
     def __init__(self, kernel_name="python"):
         self.kernel_name = kernel_name
 
@@ -132,7 +135,7 @@ def test_kernel_record_list():
     # Test .get()
     r_ = records.get(r)
     assert r == r_
-    r_ = records.get(r.kernel_id)
+    r_ = records.get(r.kernel_id or "")
     assert r == r_
 
     with pytest.raises(ValueError):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -3,9 +3,9 @@ import os
 from pathlib import Path
 
 import pytest
-import tornado
 from nbformat import writes
 from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook, new_output
+from tornado.httpclient import HTTPClientError
 
 from .utils import expected_http_error
 
@@ -28,7 +28,7 @@ async def fetch_expect_200(jp_fetch, *path_parts):
 
 
 async def fetch_expect_404(jp_fetch, *path_parts):
-    with pytest.raises(tornado.httpclient.HTTPClientError) as e:
+    with pytest.raises(HTTPClientError) as e:
         await jp_fetch("files", *path_parts, method="GET")
     assert expected_http_error(e, 404), [path_parts, e]
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -270,7 +270,7 @@ async def test_gateway_class_mappings(init_gateway, jp_serverapp):
     assert jp_serverapp.kernel_spec_manager_class.__name__ == "GatewayKernelSpecManager"
 
 
-async def test_gateway_get_kernelspecs(init_gateway, jp_fetch):
+async def test_gateway_get_kernelspecs(init_gateway, jp_serverapp, jp_fetch):
     # Validate that kernelspecs come from gateway.
     with mocked_gateway:
         r = await jp_fetch("api", "kernelspecs", method="GET")
@@ -297,11 +297,11 @@ async def test_gateway_get_named_kernelspec(init_gateway, jp_fetch):
         assert expected_http_error(e, 404)
 
 
-async def test_gateway_session_lifecycle(init_gateway, jp_root_dir, jp_fetch):
+async def test_gateway_session_lifecycle(init_gateway, jp_fetch):
     # Validate session lifecycle functions; create and delete.
 
     # create
-    session_id, kernel_id = await create_session(jp_root_dir, jp_fetch, "kspec_foo")
+    session_id, kernel_id = await create_session(jp_fetch, "kspec_foo")
 
     # ensure kernel still considered running
     assert await is_kernel_running(jp_fetch, kernel_id) is True
@@ -447,12 +447,12 @@ async def test_channel_queue_get_msg_when_response_router_had_finished():
 #
 # Test methods below...
 #
-async def create_session(root_dir, jp_fetch, kernel_name):
+async def create_session(jp_fetch, kernel_name):
     """Creates a session for a kernel.  The session is created against the server
     which then uses the gateway for kernel management.
     """
     with mocked_gateway:
-        nb_path = root_dir / "testgw.ipynb"
+        nb_path = "/testgw.ipynb"
         body = json.dumps(
             {"path": str(nb_path), "type": "notebook", "kernel": {"name": kernel_name}}
         )

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -36,7 +36,11 @@ def generate_kernelspec(name):
             "metadata": {},
         }
     }
-    kernelspec_stanza = {"name": name, "spec": spec_stanza, "resources": {}}
+    kernelspec_stanza = {
+        "name": name,
+        "spec": spec_stanza,
+        "resources": {"logo-64x64": f"f/kernelspecs/{name}/logo-64x64.png"},
+    }
     return kernelspec_stanza
 
 
@@ -275,6 +279,9 @@ async def test_gateway_get_kernelspecs(init_gateway, jp_fetch):
         kspecs = content.get("kernelspecs")
         assert len(kspecs) == 2
         assert kspecs.get("kspec_bar").get("name") == "kspec_bar"
+        assert (
+            kspecs.get("kspec_bar").get("resources")["logo-64x64"].startswith(jp_serverapp.base_url)
+        )
 
 
 async def test_gateway_get_named_kernelspec(init_gateway, jp_fetch):

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -14,7 +14,11 @@ import tornado
 from tornado.httpclient import HTTPRequest, HTTPResponse
 from tornado.web import HTTPError
 
-from jupyter_server.gateway.managers import ChannelQueue, GatewayClient
+from jupyter_server.gateway.managers import (
+    ChannelQueue,
+    GatewayClient,
+    GatewayKernelManager,
+)
 from jupyter_server.utils import ensure_async
 
 from .utils import expected_http_error
@@ -162,6 +166,15 @@ async def mock_gateway_request(url, **kwargs):
 mocked_gateway = patch("jupyter_server.gateway.managers.gateway_request", mock_gateway_request)
 mock_gateway_url = "http://mock-gateway-server:8889"
 mock_http_user = "alice"
+
+
+def mock_websocket_create_connection(recv_side_effect=None):
+    def helper(*args, **kwargs):
+        mock = MagicMock()
+        mock.recv = MagicMock(side_effect=recv_side_effect)
+        return mock
+
+    return helper
 
 
 @pytest.fixture
@@ -321,6 +334,39 @@ async def test_gateway_shutdown(init_gateway, jp_serverapp, jp_fetch, missing_ke
     assert await is_kernel_running(jp_fetch, k2) is False
 
 
+@patch("websocket.create_connection", mock_websocket_create_connection(recv_side_effect=Exception))
+async def test_kernel_client_response_router_notifies_channel_queue_when_finished(
+    init_gateway, jp_serverapp, jp_fetch
+):
+    # create
+    kernel_id = await create_kernel(jp_fetch, "kspec_bar")
+
+    # get kernel manager
+    km: GatewayKernelManager = jp_serverapp.kernel_manager.get_kernel(kernel_id)
+
+    # create kernel client
+    kc = km.client()
+
+    await ensure_async(kc.start_channels())
+
+    with pytest.raises(RuntimeError):
+        await kc.iopub_channel.get_msg(timeout=10)
+
+    all_channels = [
+        kc.shell_channel,
+        kc.iopub_channel,
+        kc.stdin_channel,
+        kc.hb_channel,
+        kc.control_channel,
+    ]
+    assert all(channel.response_router_finished if True else False for channel in all_channels)
+
+    await ensure_async(kc.stop_channels())
+
+    # delete
+    await delete_kernel(jp_fetch, kernel_id)
+
+
 async def test_channel_queue_get_msg_with_invalid_timeout():
     queue = ChannelQueue("iopub", MagicMock(), logging.getLogger())
 
@@ -350,6 +396,14 @@ async def test_channel_queue_get_msg_with_existing_item():
     received_message = await asyncio.wait_for(queue.get_msg(timeout=None), 1)
 
     assert received_message == sent_message
+
+
+async def test_channel_queue_get_msg_when_response_router_had_finished():
+    queue = ChannelQueue("iopub", MagicMock(), logging.getLogger())
+    queue.response_router_finished = True
+
+    with pytest.raises(RuntimeError):
+        await queue.get_msg()
 
 
 #

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -186,6 +186,7 @@ def init_gateway(monkeypatch):
     monkeypatch.setenv("JUPYTER_GATEWAY_HTTP_USER", mock_http_user)
     monkeypatch.setenv("JUPYTER_GATEWAY_REQUEST_TIMEOUT", "44.4")
     monkeypatch.setenv("JUPYTER_GATEWAY_CONNECT_TIMEOUT", "44.4")
+    monkeypatch.setenv("JUPYTER_GATEWAY_LAUNCH_TIMEOUT_PAD", "1.1")
     yield
     GatewayClient.clear_instance()
 
@@ -198,11 +199,10 @@ async def test_gateway_env_options(init_gateway, jp_serverapp):
         jp_serverapp.gateway_config.connect_timeout == jp_serverapp.gateway_config.request_timeout
     )
     assert jp_serverapp.gateway_config.connect_timeout == 44.4
+    assert jp_serverapp.gateway_config.launch_timeout_pad == 1.1
 
     GatewayClient.instance().init_static_args()
-    assert GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == int(
-        jp_serverapp.gateway_config.request_timeout
-    )
+    assert GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == 43
 
 
 async def test_gateway_cli_options(jp_configurable_serverapp):
@@ -211,6 +211,7 @@ async def test_gateway_cli_options(jp_configurable_serverapp):
         "--GatewayClient.http_user=" + mock_http_user,
         "--GatewayClient.connect_timeout=44.4",
         "--GatewayClient.request_timeout=96.0",
+        "--GatewayClient.launch_timeout_pad=5.1",
     ]
 
     GatewayClient.clear_instance()
@@ -221,10 +222,40 @@ async def test_gateway_cli_options(jp_configurable_serverapp):
     assert app.gateway_config.http_user == mock_http_user
     assert app.gateway_config.connect_timeout == 44.4
     assert app.gateway_config.request_timeout == 96.0
+    assert app.gateway_config.launch_timeout_pad == 5.1
     GatewayClient.instance().init_static_args()
     assert (
-        GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == 96
-    )  # Ensure KLT gets set from request-timeout
+        GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == 90
+    )  # Ensure KLT gets set from request-timeout - launch_timeout_pad
+    GatewayClient.clear_instance()
+
+
+@pytest.mark.parametrize(
+    "request_timeout,kernel_launch_timeout,expected_request_timeout,expected_kernel_launch_timeout",
+    [(50, 10, 50, 45), (10, 50, 55, 50)],
+)
+async def test_gateway_request_timeout_pad_option(
+    jp_configurable_serverapp,
+    monkeypatch,
+    request_timeout,
+    kernel_launch_timeout,
+    expected_request_timeout,
+    expected_kernel_launch_timeout,
+):
+    argv = [
+        f"--GatewayClient.request_timeout={request_timeout}",
+        "--GatewayClient.launch_timeout_pad=5",
+    ]
+
+    GatewayClient.clear_instance()
+    app = jp_configurable_serverapp(argv=argv)
+
+    monkeypatch.setattr(GatewayClient, "KERNEL_LAUNCH_TIMEOUT", kernel_launch_timeout)
+    GatewayClient.instance().init_static_args()
+
+    assert app.gateway_config.request_timeout == expected_request_timeout
+    assert GatewayClient.instance().KERNEL_LAUNCH_TIMEOUT == expected_kernel_launch_timeout
+
     GatewayClient.clear_instance()
 
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -63,6 +63,7 @@ async def test_trailing_slash(
         )
     # Capture the response from the raised exception value.
     response = err.value.response
+    assert response is not None
     assert response.code == 302
     assert "Location" in response.headers
     assert response.headers["Location"] == url_path_join(jp_base_url, expected)

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -309,7 +309,7 @@ def test_invalid_preferred_dir_not_root_subdir(tmp_path, jp_configurable_servera
     with pytest.raises(TraitError) as error:
         app = jp_configurable_serverapp(root_dir=path, preferred_dir=not_subdir_path)
 
-    assert "preferred_dir must be equal or a subdir of root_dir:" in str(error)
+    assert "preferred_dir must be equal or a subdir of root_dir. " in str(error)
 
 
 def test_invalid_preferred_dir_not_root_subdir_set(tmp_path, jp_configurable_serverapp):
@@ -321,7 +321,7 @@ def test_invalid_preferred_dir_not_root_subdir_set(tmp_path, jp_configurable_ser
     with pytest.raises(TraitError) as error:
         app.preferred_dir = not_subdir_path
 
-    assert "preferred_dir must be equal or a subdir of root_dir:" in str(error)
+    assert "preferred_dir must be equal or a subdir of root_dir. " in str(error)
 
 
 def test_observed_root_dir_updates_preferred_dir(tmp_path, jp_configurable_serverapp):

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -281,6 +281,65 @@ def test_valid_preferred_dir_does_not_exist(tmp_path, jp_configurable_serverapp)
     assert "No such preferred dir:" in str(error)
 
 
+@pytest.mark.parametrize(
+    "root_dir_loc,preferred_dir_loc",
+    [
+        ("cli", "cli"),
+        ("cli", "config"),
+        ("cli", "default"),
+        ("config", "cli"),
+        ("config", "config"),
+        ("config", "default"),
+        ("default", "cli"),
+        ("default", "config"),
+        ("default", "default"),
+    ],
+)
+def test_preferred_dir_validation(
+    root_dir_loc, preferred_dir_loc, tmp_path, jp_config_dir, jp_configurable_serverapp
+):
+    expected_root_dir = str(tmp_path)
+    expected_preferred_dir = str(tmp_path / "subdir")
+    os.makedirs(expected_preferred_dir, exist_ok=True)
+
+    argv = []
+    kwargs = {"root_dir": None}
+
+    config_lines = []
+    config_file = None
+    if root_dir_loc == "config" or preferred_dir_loc == "config":
+        config_file = jp_config_dir.joinpath("jupyter_server_config.py")
+
+    if root_dir_loc == "cli":
+        argv.append(f"--ServerApp.root_dir={expected_root_dir}")
+    if root_dir_loc == "config":
+        config_lines.append(f'c.ServerApp.root_dir = r"{expected_root_dir}"')
+    if root_dir_loc == "default":
+        expected_root_dir = os.getcwd()
+
+    if preferred_dir_loc == "cli":
+        argv.append(f"--ServerApp.preferred_dir={expected_preferred_dir}")
+    if preferred_dir_loc == "config":
+        config_lines.append(f'c.ServerApp.preferred_dir = r"{expected_preferred_dir}"')
+    if preferred_dir_loc == "default":
+        expected_preferred_dir = expected_root_dir
+
+    if config_file is not None:
+        config_file.write_text("\n".join(config_lines))
+
+    if argv:
+        kwargs["argv"] = argv
+
+    if root_dir_loc == "default" and preferred_dir_loc != "default":  # error expected
+        with pytest.raises(SystemExit):
+            jp_configurable_serverapp(**kwargs)
+    else:
+        app = jp_configurable_serverapp(**kwargs)
+        assert app.root_dir == expected_root_dir
+        assert app.preferred_dir == expected_preferred_dir
+        assert app.preferred_dir.startswith(app.root_dir)
+
+
 def test_invalid_preferred_dir_does_not_exist(tmp_path, jp_configurable_serverapp):
     path = str(tmp_path)
     path_subdir = str(tmp_path / "subdir")

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -254,14 +254,18 @@ def test_urls(config, public_url, local_url, connection_url):
 
 # Preferred dir tests
 # ----------------------------------------------------------------------------
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_valid_preferred_dir(tmp_path, jp_configurable_serverapp):
     path = str(tmp_path)
     app = jp_configurable_serverapp(root_dir=path, preferred_dir=path)
     assert app.root_dir == path
     assert app.preferred_dir == path
     assert app.root_dir == app.preferred_dir
+    assert app.contents_manager.root_dir == path
+    assert app.contents_manager.preferred_dir == ""
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_valid_preferred_dir_is_root_subdir(tmp_path, jp_configurable_serverapp):
     path = str(tmp_path)
     path_subdir = str(tmp_path / "subdir")
@@ -270,6 +274,7 @@ def test_valid_preferred_dir_is_root_subdir(tmp_path, jp_configurable_serverapp)
     assert app.root_dir == path
     assert app.preferred_dir == path_subdir
     assert app.preferred_dir.startswith(app.root_dir)
+    assert app.contents_manager.preferred_dir == "subdir"
 
 
 def test_valid_preferred_dir_does_not_exist(tmp_path, jp_configurable_serverapp):
@@ -281,26 +286,46 @@ def test_valid_preferred_dir_does_not_exist(tmp_path, jp_configurable_serverapp)
     assert "No such preferred dir:" in str(error)
 
 
+# This tests some deprecated behavior as well
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize(
-    "root_dir_loc,preferred_dir_loc",
+    "root_dir_loc,preferred_dir_loc,config_target",
     [
-        ("cli", "cli"),
-        ("cli", "config"),
-        ("cli", "default"),
-        ("config", "cli"),
-        ("config", "config"),
-        ("config", "default"),
-        ("default", "cli"),
-        ("default", "config"),
-        ("default", "default"),
+        ("cli", "cli", "ServerApp"),
+        ("cli", "cli", "FileContentsManager"),
+        ("cli", "config", "ServerApp"),
+        ("cli", "config", "FileContentsManager"),
+        ("cli", "default", "ServerApp"),
+        ("cli", "default", "FileContentsManager"),
+        ("config", "cli", "ServerApp"),
+        ("config", "cli", "FileContentsManager"),
+        ("config", "config", "ServerApp"),
+        ("config", "config", "FileContentsManager"),
+        ("config", "default", "ServerApp"),
+        ("config", "default", "FileContentsManager"),
+        ("default", "cli", "ServerApp"),
+        ("default", "cli", "FileContentsManager"),
+        ("default", "config", "ServerApp"),
+        ("default", "config", "FileContentsManager"),
+        ("default", "default", "ServerApp"),
+        ("default", "default", "FileContentsManager"),
     ],
 )
 def test_preferred_dir_validation(
-    root_dir_loc, preferred_dir_loc, tmp_path, jp_config_dir, jp_configurable_serverapp
+    root_dir_loc,
+    preferred_dir_loc,
+    config_target,
+    tmp_path,
+    jp_config_dir,
+    jp_configurable_serverapp,
 ):
     expected_root_dir = str(tmp_path)
-    expected_preferred_dir = str(tmp_path / "subdir")
-    os.makedirs(expected_preferred_dir, exist_ok=True)
+
+    os_preferred_dir = str(tmp_path / "subdir")
+    os.makedirs(os_preferred_dir, exist_ok=True)
+    config_preferred_dir = os_preferred_dir if config_target == "ServerApp" else "subdir"
+    config_preferred_dir = config_preferred_dir + "/"  # add trailing slash to ensure it is removed
+    expected_preferred_dir = "subdir"
 
     argv = []
     kwargs = {"root_dir": None}
@@ -311,18 +336,18 @@ def test_preferred_dir_validation(
         config_file = jp_config_dir.joinpath("jupyter_server_config.py")
 
     if root_dir_loc == "cli":
-        argv.append(f"--ServerApp.root_dir={expected_root_dir}")
+        argv.append(f"--{config_target}.root_dir={expected_root_dir}")
     if root_dir_loc == "config":
-        config_lines.append(f'c.ServerApp.root_dir = r"{expected_root_dir}"')
+        config_lines.append(f'c.{config_target}.root_dir = r"{expected_root_dir}"')
     if root_dir_loc == "default":
         expected_root_dir = os.getcwd()
 
     if preferred_dir_loc == "cli":
-        argv.append(f"--ServerApp.preferred_dir={expected_preferred_dir}")
+        argv.append(f"--{config_target}.preferred_dir={config_preferred_dir}")
     if preferred_dir_loc == "config":
-        config_lines.append(f'c.ServerApp.preferred_dir = r"{expected_preferred_dir}"')
+        config_lines.append(f'c.{config_target}.preferred_dir = r"{config_preferred_dir}"')
     if preferred_dir_loc == "default":
-        expected_preferred_dir = expected_root_dir
+        expected_preferred_dir = ""
 
     if config_file is not None:
         config_file.write_text("\n".join(config_lines))
@@ -335,9 +360,9 @@ def test_preferred_dir_validation(
             jp_configurable_serverapp(**kwargs)
     else:
         app = jp_configurable_serverapp(**kwargs)
-        assert app.root_dir == expected_root_dir
-        assert app.preferred_dir == expected_preferred_dir
-        assert app.preferred_dir.startswith(app.root_dir)
+        assert app.contents_manager.root_dir == expected_root_dir
+        assert app.contents_manager.preferred_dir == expected_preferred_dir
+        assert ".." not in expected_preferred_dir
 
 
 def test_invalid_preferred_dir_does_not_exist(tmp_path, jp_configurable_serverapp):
@@ -360,42 +385,39 @@ def test_invalid_preferred_dir_does_not_exist_set(tmp_path, jp_configurable_serv
     assert "No such preferred dir:" in str(error)
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_invalid_preferred_dir_not_root_subdir(tmp_path, jp_configurable_serverapp):
     path = str(tmp_path / "subdir")
     os.makedirs(path, exist_ok=True)
     not_subdir_path = str(tmp_path)
 
+    with pytest.raises(SystemExit):
+        jp_configurable_serverapp(root_dir=path, preferred_dir=not_subdir_path)
+
+
+async def test_invalid_preferred_dir_not_root_subdir_set(tmp_path, jp_configurable_serverapp):
+    path = str(tmp_path / "subdir")
+    os.makedirs(path, exist_ok=True)
+    not_subdir_path = os.path.relpath(tmp_path, path)
+
+    app = jp_configurable_serverapp(root_dir=path)
     with pytest.raises(TraitError) as error:
-        app = jp_configurable_serverapp(root_dir=path, preferred_dir=not_subdir_path)
+        app.contents_manager.preferred_dir = not_subdir_path
 
-    assert "preferred_dir must be equal or a subdir of root_dir. " in str(error)
+    assert "is outside root contents directory" in str(error.value)
 
 
-def test_invalid_preferred_dir_not_root_subdir_set(tmp_path, jp_configurable_serverapp):
+async def test_absolute_preferred_dir_not_root_subdir_set(tmp_path, jp_configurable_serverapp):
     path = str(tmp_path / "subdir")
     os.makedirs(path, exist_ok=True)
     not_subdir_path = str(tmp_path)
 
     app = jp_configurable_serverapp(root_dir=path)
+
     with pytest.raises(TraitError) as error:
-        app.preferred_dir = not_subdir_path
+        app.contents_manager.preferred_dir = not_subdir_path
 
-    assert "preferred_dir must be equal or a subdir of root_dir. " in str(error)
-
-
-def test_observed_root_dir_updates_preferred_dir(tmp_path, jp_configurable_serverapp):
-    path = str(tmp_path)
-    new_path = str(tmp_path / "subdir")
-    os.makedirs(new_path, exist_ok=True)
-
-    app = jp_configurable_serverapp(root_dir=path, preferred_dir=path)
-    app.root_dir = new_path
-    assert app.preferred_dir == new_path
-
-
-def test_observed_root_dir_does_not_update_preferred_dir(tmp_path, jp_configurable_serverapp):
-    path = str(tmp_path)
-    new_path = str(tmp_path.parent)
-    app = jp_configurable_serverapp(root_dir=path, preferred_dir=path)
-    app.root_dir = new_path
-    assert app.preferred_dir == path
+    if os.name == "nt":
+        assert "is not a relative API path" in str(error.value)
+    else:
+        assert "Preferred directory not found" in str(error.value)

--- a/tests/test_serverapp.py
+++ b/tests/test_serverapp.py
@@ -328,7 +328,7 @@ def test_preferred_dir_validation(
         config_file.write_text("\n".join(config_lines))
 
     if argv:
-        kwargs["argv"] = argv
+        kwargs["argv"] = argv  # type:ignore
 
     if root_dir_loc == "default" and preferred_dir_loc != "default":  # error expected
         with pytest.raises(SystemExit):

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -60,7 +60,7 @@ async def test_no_terminals(jp_fetch):
     assert len(data) == 0
 
 
-async def test_terminal_create(jp_fetch, jp_cleanup_subprocesses):
+async def test_terminal_create(jp_fetch):
     resp = await jp_fetch(
         "api",
         "terminals",
@@ -80,13 +80,10 @@ async def test_terminal_create(jp_fetch, jp_cleanup_subprocesses):
     data = json.loads(resp_list.body.decode())
 
     assert len(data) == 1
-    assert data[0] == term
-    await jp_cleanup_subprocesses()
+    assert data[0]["name"] == term["name"]
 
 
-async def test_terminal_create_with_kwargs(
-    jp_fetch, jp_ws_fetch, terminal_path, jp_cleanup_subprocesses
-):
+async def test_terminal_create_with_kwargs(jp_fetch, jp_ws_fetch, terminal_path):
     resp_create = await jp_fetch(
         "api",
         "terminals",
@@ -109,12 +106,9 @@ async def test_terminal_create_with_kwargs(
     data = json.loads(resp_get.body.decode())
 
     assert data["name"] == term_name
-    await jp_cleanup_subprocesses()
 
 
-async def test_terminal_create_with_cwd(
-    jp_fetch, jp_ws_fetch, terminal_path, jp_cleanup_subprocesses
-):
+async def test_terminal_create_with_cwd(jp_fetch, jp_ws_fetch, terminal_path):
     resp = await jp_fetch(
         "api",
         "terminals",
@@ -145,11 +139,10 @@ async def test_terminal_create_with_cwd(
     ws.close()
 
     assert os.path.basename(terminal_path) in message_stdout
-    await jp_cleanup_subprocesses()
 
 
 async def test_terminal_create_with_relative_cwd(
-    jp_fetch, jp_ws_fetch, jp_root_dir, terminal_root_dir, jp_cleanup_subprocesses
+    jp_fetch, jp_ws_fetch, jp_root_dir, terminal_root_dir
 ):
     resp = await jp_fetch(
         "api",
@@ -182,7 +175,6 @@ async def test_terminal_create_with_relative_cwd(
 
     expected = terminal_root_dir.name if sys.platform == "win32" else str(terminal_root_dir)
     assert expected in message_stdout
-    await jp_cleanup_subprocesses()
 
 
 async def test_terminal_create_with_bad_cwd(jp_fetch, jp_ws_fetch, jp_cleanup_subprocesses):
@@ -217,7 +209,6 @@ async def test_terminal_create_with_bad_cwd(jp_fetch, jp_ws_fetch, jp_cleanup_su
     ws.close()
 
     assert non_existing_path not in message_stdout
-    await jp_cleanup_subprocesses()
 
 
 async def test_culling_config(jp_server_config, jp_configurable_serverapp):
@@ -229,7 +220,7 @@ async def test_culling_config(jp_server_config, jp_configurable_serverapp):
     assert terminal_mgr_settings.cull_interval == CULL_INTERVAL
 
 
-async def test_culling(jp_server_config, jp_fetch, jp_cleanup_subprocesses):
+async def test_culling(jp_server_config, jp_fetch):
     # POST request
     resp = await jp_fetch(
         "api",
@@ -259,4 +250,3 @@ async def test_culling(jp_server_config, jp_fetch, jp_cleanup_subprocesses):
             await asyncio.sleep(1)
 
     assert culled
-    await jp_cleanup_subprocesses()

--- a/tests/unix_sockets/test_serverapp_integration.py
+++ b/tests/unix_sockets/test_serverapp_integration.py
@@ -35,6 +35,7 @@ def test_shutdown_sock_server_integration(jp_unix_socket_file):
     )
 
     complete = False
+    assert p.stderr is not None
     for line in iter(p.stderr.readline, b""):
         if url in line:
             complete = True

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import json
 
-import tornado
+from tornado.httpclient import HTTPClientError
+from tornado.web import HTTPError
 
 some_resource = "The very model of a modern major general"
 
@@ -20,7 +21,7 @@ def mkdir(tmp_path, *parts):
 def expected_http_error(error, expected_code, expected_message=None):
     """Check that the error matches the expected output error."""
     e = error.value
-    if isinstance(e, tornado.web.HTTPError):
+    if isinstance(e, HTTPError):
         if expected_code != e.status_code:
             return False
         if expected_message is not None and expected_message != str(e):
@@ -28,8 +29,8 @@ def expected_http_error(error, expected_code, expected_message=None):
         return True
     elif any(
         [
-            isinstance(e, tornado.httpclient.HTTPClientError),
-            isinstance(e, tornado.httpclient.HTTPError),
+            isinstance(e, HTTPClientError),
+            isinstance(e, HTTPError),
         ]
     ):
         if expected_code != e.code:


### PR DESCRIPTION
should be backwards compatible, the new javascript sends session_id with the payload, emtpy if it is requesting a new one, otherwise it is polling a kernel startup. if the session_id is None it behaves like before, waits until the kernel is ready and answers the post request